### PR TITLE
Small fixes for Expression Trees

### DIFF
--- a/src/expression_manager/expression_helper_functions.py
+++ b/src/expression_manager/expression_helper_functions.py
@@ -304,10 +304,10 @@ def op_expression_to_string(expression_node: ExpressionNode, cast_to: Expression
         return f"{left_node.value!s}[{expression_to_string(right_node, cast_to)}"
 
     left_value = expression_to_string(
-        left_node, cast_to if left_node.type != ExpressionType.CONST else ExpressionValueTypeHint()
+        left_node, cast_to if left_node.type != ExpressionType.CONST else ExpressionValueTypeHint(cast_to.opencl_type)
     )
     right_value = expression_to_string(
-        right_node, cast_to if right_node.type != ExpressionType.CONST else ExpressionValueTypeHint()
+        right_node, cast_to if right_node.type != ExpressionType.CONST else ExpressionValueTypeHint(cast_to.opencl_type)
     )
 
     if operation == ExpressionOperationType.MIN:

--- a/src/expression_manager/expression_helper_functions.py
+++ b/src/expression_manager/expression_helper_functions.py
@@ -303,8 +303,12 @@ def op_expression_to_string(expression_node: ExpressionNode, cast_to: Expression
             return f"{left_node.value!s}[{expression_to_string(right_node, cast_to)}]"
         return f"{left_node.value!s}[{expression_to_string(right_node, cast_to)}"
 
-    left_value = expression_to_string(left_node, cast_to)
-    right_value = expression_to_string(right_node, cast_to)
+    left_value = expression_to_string(
+        left_node, cast_to if left_node.type != ExpressionType.CONST else ExpressionValueTypeHint()
+    )
+    right_value = expression_to_string(
+        right_node, cast_to if right_node.type != ExpressionType.CONST else ExpressionValueTypeHint()
+    )
 
     if operation == ExpressionOperationType.MIN:
         return f"min({left_value}, {right_value})"

--- a/src/expression_manager/expression_manager.py
+++ b/src/expression_manager/expression_manager.py
@@ -230,6 +230,8 @@ class ExpressionManager(metaclass=Singleton):
             s1_abs_value_node = copy.deepcopy(s1)
             s1_abs_value_node.value = abs(s1_abs_value_node.value)
             return self._optimized_nodes_sub(s0, s1_abs_value_node, value_type_hint)
+        if s0.value_type_hint.is_pointer and s1.type == ExpressionType.CONST and s1.value != int(s1.value):
+            s1 = copy.deepcopy(self._optimized_nodes_to_original[s1])
 
         plus_node = self._parse_and_optimize_node_sum(s0, s1, value_type_hint)
         if plus_node is None:

--- a/src/expression_manager/expression_manager.py
+++ b/src/expression_manager/expression_manager.py
@@ -428,7 +428,7 @@ class ExpressionManager(metaclass=Singleton):
 
         return logical_not_node
 
-    def add_kernel_argument(self, arg: KernelArgument, offset: int, check_duplicate: bool = True) -> ExpressionNode:  # noqa: FBT001, FBT002
+    def add_kernel_argument(self, arg: KernelArgument, offset: int) -> ExpressionNode:
         if arg.hidden:
             for reg_type in CONSTANT_VALUES:
                 reg_type_name = CONSTANT_VALUES[reg_type][0]
@@ -442,7 +442,7 @@ class ExpressionManager(metaclass=Singleton):
         opencl_type, qualifiers = get_kernel_argument_type_and_qualifiers(arg)
         value_type_hint = ExpressionValueTypeHint(opencl_type, qualifiers, arg.const)
 
-        var_node = self.add_variable_node(name, value_type_hint, check_duplicate)
+        var_node = self.add_variable_node(name, value_type_hint)
 
         # For kernel argument node make a copy, because variable node can be changed during decompilation
         arg_name: str = var_node.value
@@ -632,12 +632,7 @@ class ExpressionManager(metaclass=Singleton):
             return True
         return False
 
-    def add_variable_node(
-        self,
-        name: str,
-        value_type_hint: ExpressionValueTypeHint,
-        check_duplicate: bool = True,  # noqa: FBT001, FBT002
-    ) -> ExpressionNode:
+    def add_variable_node(self, name: str, value_type_hint: ExpressionValueTypeHint) -> ExpressionNode:
         assert isinstance(value_type_hint, ExpressionValueTypeHint)
         # Sometimes variable name will be passed in *{var_name} format,
         # which indicates that it is a pointer
@@ -645,7 +640,7 @@ class ExpressionManager(metaclass=Singleton):
         value_type_hint.is_pointer |= is_pointer
 
         existing_var_info = self.get_variable_info(var_name)
-        if check_duplicate and existing_var_info is not None:
+        if existing_var_info is not None:
             # There are cases when we make VAR from one value,
             # but then it is reassigned to another value with another type
             # For those cases, we need to make all types fit into variable type
@@ -657,8 +652,8 @@ class ExpressionManager(metaclass=Singleton):
         if var_name.find(VECTOR_COMPONENT_DELIMITER) != -1:
             base_var_name, var_components = var_name.split(VECTOR_COMPONENT_DELIMITER)
             if var_components != "" and value_type_hint.number_of_components() != len(var_components):
-                if check_duplicate and self.get_variable_info(base_var_name) is None:
-                    self.add_variable_node(base_var_name, value_type_hint, check_duplicate)
+                if self.get_variable_info(base_var_name) is None:
+                    self.add_variable_node(base_var_name, value_type_hint)
                 value_type_hint = value_type_hint.set_number_of_components(1)
 
         var_node = create_var_node(var_name, value_type_hint)

--- a/src/expression_manager/expression_node.py
+++ b/src/expression_manager/expression_node.py
@@ -249,7 +249,7 @@ class ExpressionNode:
     def invert(self) -> "ExpressionNode":
         return self
 
-    def needs_cast(  # noqa: C901, PLR0911, PLR0912
+    def needs_cast(  # noqa: PLR0911, PLR0912
         self, to_hint: ExpressionValueTypeHint
     ) -> bool:
         from_hint = self.value_type_hint
@@ -285,8 +285,6 @@ class ExpressionNode:
                     to_hint_max = range_max
                 return is_to_type_smaller and not (self.value >= to_hint_min and self.value <= to_hint_max)
             # from unsigned type to signed or from signed type to unsigned
-            if re.fullmatch(r"-?\d+.\d+", str(self.value)) is not None:
-                return False
             if re.fullmatch(r"0x[\da-f]+", str(self.value)) is not None:
                 return False
             return not (isinstance(self.value, int) and self.value >= 0)

--- a/src/instructions/flat/flat_load.py
+++ b/src/instructions/flat/flat_load.py
@@ -15,10 +15,12 @@ def get_output_for_different_vector_types(
         close_square_bracket_position = output.find("]")
         element_number = output[open_square_bracket_position + 1 : close_square_bracket_position]
         second_term_separator = element_number.find(" + ")
-        vector_offset_value = float(element_number[second_term_separator + 3 :])
+        vector_offset_numerator, vector_offset_denominator = map(
+            int, element_number[second_term_separator + 4 : -1].split("/")
+        )
         vector_size = output_type_hint.size_bytes()
         one_element_size = variable_type_hint.set_number_of_components(1).size_bytes()
-        curr_element = int(vector_offset_value * vector_size / one_element_size)
+        curr_element = int(vector_offset_numerator / vector_offset_denominator * vector_size / one_element_size)
         output = output[: output.find(" + ")] + "]"
     else:
         curr_element = 0

--- a/src/kernel_parser/amdgpu_dis_parser.py
+++ b/src/kernel_parser/amdgpu_dis_parser.py
@@ -101,7 +101,7 @@ def _convert_args_to_offset_to_content(args: list) -> dict[str, RegisterContent]
 
             int_offset = int(offset, base=16)
 
-            expr_node = ExpressionManager().add_kernel_argument(_make_argument(idx, arg), int_offset, False)  # noqa: FBT003
+            expr_node = ExpressionManager().add_kernel_argument(_make_argument(idx, arg), int_offset)
         elif _ARG_KIND_TO_REGISTER_TYPE.get(value_kind) is not None:
             reg_type = _ARG_KIND_TO_REGISTER_TYPE[value_kind]
             expr_node = ExpressionManager().add_register_node(reg_type, _ARG_KIND_TO_VALUE[value_kind])

--- a/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1010.cl
+++ b/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1010.cl
@@ -19,8 +19,8 @@ void loop_with_unrolling_breaker(__global int *data, int x, int unrollingBreaker
             var7 = (int)var8 + var6;
             var8 = var8 + 1;
             var9 = var9;
-            var10 = var10 + (-1 / 4);
-            var11 = var11 + (-1 / 4);
+            var10 = var10 + ((int)-1 / 4);
+            var11 = var11 + ((int)-1 / 4);
             var12 = 1 != (0 - var0);
             var12 = 1 != (0 - var0);
         } while (1 != (0 - var0));

--- a/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1010.cl
+++ b/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1010.cl
@@ -19,8 +19,8 @@ void loop_with_unrolling_breaker(__global int *data, int x, int unrollingBreaker
             var7 = (int)var8 + var6;
             var8 = var8 + 1;
             var9 = var9;
-            var10 = var10 + -0.25;
-            var11 = var11 + -0.25;
+            var10 = var10 + (-1 / 4);
+            var11 = var11 + (-1 / 4);
             var12 = 1 != (0 - var0);
             var12 = 1 != (0 - var0);
         } while (1 != (0 - var0));

--- a/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1030.cl
+++ b/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1030.cl
@@ -19,8 +19,8 @@ void loop_with_unrolling_breaker(__global int *data, int x, int unrollingBreaker
             var7 = (int)var8 + var6;
             var8 = var8 + 1;
             var9 = var9;
-            var10 = var10 + (-1 / 4);
-            var11 = var11 + (-1 / 4);
+            var10 = var10 + ((int)-1 / 4);
+            var11 = var11 + ((int)-1 / 4);
             var12 = 1 != (0 - var0);
             var12 = 1 != (0 - var0);
         } while (1 != (0 - var0));

--- a/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1030.cl
+++ b/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_dcmpl-gfx1030.cl
@@ -19,8 +19,8 @@ void loop_with_unrolling_breaker(__global int *data, int x, int unrollingBreaker
             var7 = (int)var8 + var6;
             var8 = var8 + 1;
             var9 = var9;
-            var10 = var10 + -0.25;
-            var11 = var11 + -0.25;
+            var10 = var10 + (-1 / 4);
+            var11 = var11 + (-1 / 4);
             var12 = 1 != (0 - var0);
             var12 = 1 != (0 - var0);
         } while (1 != (0 - var0));

--- a/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_hands.cl
+++ b/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_hands.cl
@@ -19,8 +19,8 @@ void loop_with_unrolling_breaker(__global int *data, int x, int unrollingBreaker
             var7 = (int)var8 + var6;
             var8 = var8 + 1;
             var9 = var9;
-            var10 = var10 + (-1 / 4);
-            var11 = var11 + (-1 / 4);
+            var10 = var10 + ((int)-1 / 4);
+            var11 = var11 + ((int)-1 / 4);
             var12 = 1 != (0 - var0);
             var12 = 1 != (0 - var0);
         } while (1 != (0 - var0));

--- a/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_hands.cl
+++ b/tests/loops_kernels/loop_with_unrolling_breaker/loop_with_unrolling_breaker_hands.cl
@@ -19,8 +19,8 @@ void loop_with_unrolling_breaker(__global int *data, int x, int unrollingBreaker
             var7 = (int)var8 + var6;
             var8 = var8 + 1;
             var9 = var9;
-            var10 = var10 + -0.25;
-            var11 = var11 + -0.25;
+            var10 = var10 + (-1 / 4);
+            var11 = var11 + (-1 / 4);
             var12 = 1 != (0 - var0);
             var12 = 1 != (0 - var0);
         } while (1 != (0 - var0));

--- a/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_dcmpl-gfx1010.cl
+++ b/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_dcmpl-gfx1010.cl
@@ -69,7 +69,7 @@ void loop_kernel_2(__global uint *data, uint x, uint y, uint unrollingBreaker)
             var8 = (uint)UNKNOWN VALUE + var8;
             var9 = data + var7 + -1;
             var11 = var8;
-            var10 = var10 + -0.25;
+            var10 = var10 + (-1 / 4);
             var8 = var8 * x;
             *var12 = var11;
         } while (!((var7 - 1) == 0));

--- a/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_dcmpl-gfx1030.cl
+++ b/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_dcmpl-gfx1030.cl
@@ -69,7 +69,7 @@ void loop_kernel_2(__global uint *data, uint x, uint y, uint unrollingBreaker)
             var8 = (uint)UNKNOWN VALUE + var8;
             var9 = data + var7 + -1;
             var11 = var8;
-            var10 = var10 + -0.25;
+            var10 = var10 + (-1 / 4);
             var8 = var8 * x;
             *var12 = var11;
         } while (!((var7 - 1) == 0));

--- a/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_dcmpl.cl
+++ b/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_dcmpl.cl
@@ -70,7 +70,7 @@ void loop_kernel_2(__global uint *data, uint x, uint y, uint unrollingBreaker)
             var12 = var8;
             var0 = *var12;
             var8 = var8 + -1;
-            var9 = var9 + -0.25;
+            var9 = var9 + (-1 / 4);
             var10 = var10 + -1;
             var11 = var0 + var11;
             *var12 = var11;

--- a/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_hands-gfx.cl
+++ b/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_hands-gfx.cl
@@ -69,7 +69,7 @@ void loop_kernel_2(__global uint *data, uint x, uint y, uint unrollingBreaker)
             var8 = (uint)UNKNOWN VALUE + var8;
             var9 = data + var7 + -1;
             var11 = var8;
-            var10 = var10 + -0.25;
+            var10 = var10 + (-1 / 4);
             var8 = var8 * x;
             *var12 = var11;
         } while (!((var7 - 1) == 0));

--- a/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_hands.cl
+++ b/tests/loops_kernels/simple_loop_kernels/simple_loop_kernels_hands.cl
@@ -70,7 +70,7 @@ void loop_kernel_2(__global uint *data, uint x, uint y, uint unrollingBreaker)
             var12 = var8;
             var0 = *var12;
             var8 = var8 + -1;
-            var9 = var9 + -0.25;
+            var9 = var9 + (-1 / 4);
             var10 = var10 + -1;
             var11 = var0 + var11;
             *var12 = var11;


### PR DESCRIPTION
- Fixed compile error due to const expression being evaluated to double value when using it as a pointer offset
- Removed some redundant stuff