### PR TITLE
add IR kernel and IR instructions

### DIFF
--- a/src/ir/TemporaryVariableAllocator.py
+++ b/src/ir/TemporaryVariableAllocator.py
@@ -1,0 +1,16 @@
+class tva:
+    _counters: dict[str, int] = {}
+
+    @classmethod
+    def generate(cls, prefix: str = "tmp") -> str:
+        if prefix not in cls._counters:
+            cls._counters[prefix] = 0
+        
+        count = cls._counters[prefix]
+        cls._counters[prefix] += 1
+        
+        return f"{prefix}_{count}"
+
+    @classmethod
+    def reset(cls):
+        cls._counters.clear()

--- a/src/ir/instructions/common/add.py
+++ b/src/ir/instructions/common/add.py
@@ -1,0 +1,73 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import Reg_ty, RegOrVal_ty, get_reg_rang
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.vop2.v_add import VAdd
+from src.instructions.vop2.v_addc import VAddc
+
+
+class Add(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar: bool = False):
+        super().__init__("add", destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+        
+    def _is_64bit(self) -> bool:
+        return self.destination.bit_width == 64
+    
+    def _get_normalize_opcode(self, is_addc: bool = False) -> str:
+        if is_addc:
+            return "v_addc_u32"
+        return "v_add_u32"
+    
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        if not self._is_64bit():
+            return ctx.emit_backend(
+                VAdd,
+                self._get_normalize_opcode(),
+                self.operands,
+                "u32",
+            )
+
+        dest_lo, dest_hi = get_reg_rang(self.destination)
+        op1_lo, op1_hi = get_reg_rang(self.operand1)
+        op2_lo, op2_hi = get_reg_rang(self.operand2)
+
+        ctx.emit_backend(
+            VAdd,
+            self._get_normalize_opcode(),
+            [dest_lo, op1_lo, op2_lo],
+            "u32",
+        )
+        return ctx.emit_backend(
+            VAddc,
+            self._get_normalize_opcode(is_addc=True),
+            [dest_hi, op1_hi, op2_hi],
+            "u32",
+        )
+
+
+
+class AddC(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar: bool = False):
+        super().__init__("addc", destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+        
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_addc_u32"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VAddc,
+            self._get_normalize_opcode(),
+            self.operands,
+            "u32",
+        )
+
+        

--- a/src/ir/instructions/common/barrier.py
+++ b/src/ir/instructions/common/barrier.py
@@ -1,0 +1,18 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.instructions.sopp.s_waitcnt import SWaitcnt
+from src.ir.instructions.lowering import NodeLoweringContext
+
+
+class Barrier(GenericInstruction):
+    def __init__(self, is_scalar: bool):
+        super().__init__("barrier", is_scalar=is_scalar)
+   
+    def _get_normalize_opcode(self) -> str:
+        return "s_waitcnt"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SWaitcnt,
+            self._get_normalize_opcode(),
+            self.operands,
+        )

--- a/src/ir/instructions/common/bfe.py
+++ b/src/ir/instructions/common/bfe.py
@@ -1,0 +1,41 @@
+from src.ir.registers.reg import RegOrVal_ty, Reg32
+from src.ir.instructions.generic import GenericInstruction
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sop2.s_bfe import SBfe
+
+class bfe(GenericInstruction):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, signed=False,  is_scalar=False):
+        name =  "bfe_s" if signed else "bfe_u"   
+        super().__init__(name, destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+        self.signed = signed
+
+    def _is_64bit(self) -> bool:
+        return False
+
+    def _get_normalize_opcode(self) -> str:
+        if self.signed:
+            return "s_bfe_i32" if self.is_scalar() else "v_bfe_i32"
+        else:
+            return "s_bfe_u32" if self.is_scalar() else "v_bfe_u32"
+    
+    def get_suffix(self) -> str:
+        if self.signed:
+            return "i32"
+        return "u32"
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SBfe,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+    
+
+class bfe_s(bfe):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar=False):
+        super().__init__(destination, operand1, operand2, signed=True, is_scalar=is_scalar)

--- a/src/ir/instructions/common/compare.py
+++ b/src/ir/instructions/common/compare.py
@@ -1,0 +1,75 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import PredReg, RegOrVal_ty
+
+from src.instructions.vopc.v_cmp_eq import VCmpEq
+from src.instructions.vopc.v_cmp_ge import VCmpGe
+from src.instructions.vopc.v_cmp_gt import VCmpGt
+from src.instructions.vopc.v_cmp_le import VCmpLe
+from src.instructions.vopc.v_cmp_lt import VCmpLt
+from src.instructions.vopc.v_cmp_ne import VCmpNe
+from src.ir.instructions.lowering import NodeLoweringContext
+
+class BaseCompare(GenericInstruction):
+    operation: str
+    backend_instruction: type
+
+    def __init__(
+        self,
+        destination: PredReg,
+        operand1: RegOrVal_ty,
+        operand2: RegOrVal_ty,
+        is_scalar: bool = False,
+    ):
+        super().__init__(f"cmp.{self.operation}", destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+
+    def _get_normalize_opcode(self) -> str:
+        return f'v_cmp_{self.operation}_i32'
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            self.backend_instruction,
+            self._get_normalize_opcode(),
+            self.operands,
+            "i32"
+        )
+
+class CompareEq(BaseCompare):
+    operation = "eq"
+    backend_instruction = VCmpEq
+
+class CompareNe(BaseCompare):
+    operation = "ne"
+    backend_instruction = VCmpNe
+
+class CompareLt(BaseCompare):
+    operation = "lt"
+    backend_instruction = VCmpLt
+
+class CompareLe(BaseCompare):
+    operation = "le"
+    backend_instruction = VCmpLe
+
+class CompareGt(BaseCompare):
+    operation = "gt"
+    backend_instruction = VCmpGt
+
+class CompareGe(BaseCompare):
+    operation = "ge"
+    backend_instruction = VCmpGe
+
+_COMPARE_CLASSES = {
+    "eq": CompareEq,
+    "ne": CompareNe,
+    "lg": CompareNe,
+    "lt": CompareLt,
+    "le": CompareLe,
+    "gt": CompareGt,
+    "ge": CompareGe,
+}
+
+
+def get_compare_class(comparison: str) -> type[BaseCompare]:
+    return _COMPARE_CLASSES[comparison]

--- a/src/ir/instructions/common/cselect.py
+++ b/src/ir/instructions/common/cselect.py
@@ -1,0 +1,19 @@
+from src.ir.instructions.generic import GenericInstruction
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.vop2.v_cndmask import VCndmask
+
+class CSelect(GenericInstruction):
+    def __init__(self, dst, src0, src1, cond,  is_scalar: bool):
+        super().__init__("cselect", dst, src0, src1, cond, is_scalar=is_scalar)
+   
+    def _get_normalize_opcode(self) -> str:
+        return "v_cndmask_b32"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VCndmask,
+            self._get_normalize_opcode(),
+            self.operands,
+            "b32",
+        )

--- a/src/ir/instructions/common/cvt.py
+++ b/src/ir/instructions/common/cvt.py
@@ -1,0 +1,100 @@
+from src.ir.registers.reg import Reg_ty, RegOrVal_ty, Reg64, Val, get_reg_rang
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sop1.s_mov import SMov
+from src.instructions.vop2.v_ashrrev import VAshrrev
+from src.instructions.sop2.s_and import SAnd
+from src.instructions.vop1.v_cvt import VCvt
+
+class Cvt64_32(GenericInstruction):
+    def __init__(self, destination: Reg64, operand1: RegOrVal_ty,
+                 signed=False,  is_scalar=False):
+        super().__init__("cvt32to64", destination, operand1, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.signed = signed
+    
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        dest_lo, dest_hi = get_reg_rang(self.destination)
+        ctx.emit_backend(
+            SMov,
+            "s_mov_b32",
+            [dest_lo, self.operand1],
+            "b32",
+        )
+        
+        if self.signed:
+            return ctx.emit_backend(
+                VAshrrev,
+                "v_ashrrev_i32",
+                [dest_hi, Val("31"), self.operand1],
+                "i32",
+            )
+        
+        return ctx.emit_backend(
+                SMov,
+                "s_mov_b32",
+                [dest_hi, Val("0")],
+                "b32",
+            )
+       
+
+class Cvt64_32_s(Cvt64_32):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, is_scalar=False):
+        super().__init__(destination, operand1, is_scalar=is_scalar, signed=True)
+    
+class Cvt32_16(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, 
+                 signed: bool = False, is_scalar: bool = False):
+        super().__init__("cvt16to32", destination, operand1, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.signed = signed
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(
+            SAnd,
+            "s_and_b32",
+            [self.destination, Val("0xffff"), self.operand1],
+            "b32",
+        )
+        
+
+class Cvt_i32_f32(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, is_scalar: bool = False):
+        super().__init__("cvt_f32_to_i32", destination, operand1, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+    
+    def _get_normalize_opcode(self) -> str:
+        return "v_cvt_i32_f32"
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(
+            VCvt,
+            self._get_normalize_opcode(),
+            self.operands,
+            "i32_f32",
+        )
+    
+class Cvt_f64_u32(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, is_scalar: bool = False):
+        super().__init__("cvt_u32_to_f64", destination, operand1, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+    
+    def _get_normalize_opcode(self) -> str:
+        return "v_cvt_f64_u32"
+    
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(
+            VCvt,
+            self._get_normalize_opcode(),
+            self.operands,
+            "f64_u32",
+        )

--- a/src/ir/instructions/common/endpgm.py
+++ b/src/ir/instructions/common/endpgm.py
@@ -1,0 +1,18 @@
+from src.ir.instructions.generic import GenericInstruction
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sopp.s_endpgm import SEndpgm
+
+class EndPgm(GenericInstruction):
+    def __init__(self, is_scalar: bool):
+        super().__init__("endpgm", is_scalar=is_scalar)
+   
+    def _get_normalize_opcode(self) -> str:
+        return "s_endpgm"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SEndpgm,
+            self._get_normalize_opcode(),
+            self.operands,
+        )

--- a/src/ir/instructions/common/load.py
+++ b/src/ir/instructions/common/load.py
@@ -1,0 +1,70 @@
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.smem.s_load import SLoad
+from src.instructions.flat.flat_load import FlatLoad
+
+from src.ir.registers.reg import Reg64, Reg_ty, Val
+from src.ir.instructions.generic import GenericInstruction
+
+class Load(GenericInstruction):
+    def __init__(self, destination: Reg_ty, address: Reg64, offset: Val, is_scalar, size):
+        self.destination = destination
+        self.address = address
+        self.offset = offset if offset != None else Val("0")
+        super().__init__("load", self.destination, self.address, self.offset, is_scalar=is_scalar)
+        self.size = size
+
+    def _get_normalize_opcode(self) -> str:
+        prefix = "s_load" if self.is_scalar() else "flat_load"
+
+        if self.size<= 32:
+            return f"{prefix}_dword"
+        elif self.size <= 64:
+            return f"{prefix}_dwordx2"
+        else:
+            return f"{prefix}_dwordx4"
+        
+    def _get_opcode(self):
+        return SLoad if self.is_scalar() else FlatLoad
+
+    def get_suffix(self):
+        if self.size<= 32:
+            return "dword"
+        elif self.size <= 64:
+            return "dwordx2"
+        else:
+            return "dwordx4"
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(
+            self._get_opcode(),
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+
+                
+class Load32(Load):
+    def __init__(self, destination: Reg_ty, address: Reg64, offset: Val | None = None, is_scalar: bool = False):
+        super().__init__(destination, address, offset, is_scalar=True, size=32)
+
+class Load64(Load):
+    def __init__(self, destination: Reg_ty, address: Reg64, offset: Val | None = None, is_scalar: bool = False):
+        super().__init__(destination, address, offset, is_scalar=True, size=64)
+
+class Load128(Load):
+    def __init__(self, destination: Reg_ty, address: Reg64, offset: Val | None = None, is_scalar: bool = False):
+        super().__init__(destination, address, offset, is_scalar=True, size=128)
+
+
+class FLoad32(Load):
+    def __init__(self, destination: Reg_ty, address: Reg64, offset: Val | None = None, is_scalar: bool = True):
+        super().__init__(destination, address, offset, is_scalar=False, size=32)
+
+class FLoad64(Load):
+    def __init__(self, destination: Reg_ty, address: Reg64, offset: Val | None = None, is_scalar: bool = True):
+        super().__init__(destination, address, offset, is_scalar=False, size=64)
+
+class FLoad128(Load):
+    def __init__(self, destination: Reg_ty, address: Reg64, offset: Val | None = None, is_scalar: bool = True):
+        super().__init__(destination, address, offset, is_scalar=False, size=128)

--- a/src/ir/instructions/common/logical.py
+++ b/src/ir/instructions/common/logical.py
@@ -1,0 +1,57 @@
+from src.ir.registers.reg import Reg_ty, RegOrVal_ty, Val
+from src.ir.instructions.generic import GenericInstruction
+from src.instructions.sop2.s_and import SAnd
+from src.instructions.sop2.s_xor import SXor
+from src.instructions.sop2.s_or import SOr
+from src.ir.instructions.lowering import NodeLoweringContext
+
+
+class LogicalInstruction(GenericInstruction):
+    operation: str
+    backend_instruction: type
+
+    def __init__(self, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__(self.operation, destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        if isinstance(operand2, Val) and not is_scalar:
+            self.operand1 = operand2
+            self.operand2 = operand1
+        else:
+            self.operand1 = operand1
+            self.operand2 = operand2
+        
+
+    def _is_64bit(self) -> bool:
+        return self.destination.bit_width == 64
+
+    def _get_normalize_opcode(self) -> str:
+        if self._is_64bit():
+            return f's_{self.operation}_b64'
+        return f's_{self.operation}_b32'
+    
+    def get_suffix(self):
+        return "b64" if self._is_64bit() else "b32"
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(
+            self.backend_instruction,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+
+
+class And(LogicalInstruction):
+    operation = "and"
+    backend_instruction = SAnd
+
+
+class Or(LogicalInstruction):
+    operation = "or"
+    backend_instruction = SOr
+
+
+class Xor(LogicalInstruction):
+    operation = "xor"
+    backend_instruction = SXor

--- a/src/ir/instructions/common/lshl.py
+++ b/src/ir/instructions/common/lshl.py
@@ -1,0 +1,94 @@
+from src.ir.registers.reg import Reg_ty, RegOrVal_ty
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.vop2.v_lshlrev import VLshlrev
+from src.instructions.vop2.v_lshrrev import VLshrrev
+from src.instructions.vop2.v_ashrrev import VAshrrev
+
+
+class ShiftInstruction(GenericInstruction):
+    def __init__(self, name: str, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__(name, destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+
+    def _is_64bit(self) -> bool:
+        return self.destination.bit_width == 64
+    
+    def get_suffix(self):
+        if self._is_64bit():
+            return "b64"
+        return "b32"
+
+
+class LShl_Rev(ShiftInstruction):
+    def __init__(self, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__("lshl", destination, operand1, operand2, is_scalar=is_scalar)
+
+    def _get_normalize_opcode(self) -> str:
+        if self._is_64bit():
+            return "v_lshlrev_b64"
+        return "v_lshlrev_b32"
+    
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VLshlrev,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+
+
+class LShr_Rev(ShiftInstruction):
+    def __init__(self, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__("rshl", destination, operand1, operand2, is_scalar=is_scalar)
+
+
+    def _get_normalize_opcode(self) -> str:
+        if self._is_64bit():
+            return "v_lshrrev_b64"
+        return "v_lshrrev_b32"
+        
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VLshrrev,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+
+class AShr_Rev(ShiftInstruction):
+    def __init__(self, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__("rshl", destination, operand1, operand2, is_scalar=is_scalar)
+
+    def _get_normalize_opcode(self) -> str:
+        if self._is_64bit():
+            return "v_ashrrev_i64"
+        return "v_ashrrev_i32"
+ 
+    def get_suffix(self):
+        if self._is_64bit():
+            return "i64"
+        return "i32"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VAshrrev,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+    
+class LShl(LShl_Rev):
+    def __init__(self, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__(destination, operand2, operand1, is_scalar=is_scalar)
+
+class LShr(LShr_Rev):
+    def __init__(self, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__(destination, operand2, operand1, is_scalar=is_scalar)
+
+class AShr(AShr_Rev):
+    def __init__(self, destination: Reg_ty, operand1: Reg_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__(destination, operand2, operand1, is_scalar=is_scalar)

--- a/src/ir/instructions/common/mad.py
+++ b/src/ir/instructions/common/mad.py
@@ -1,0 +1,59 @@
+from src.ir.registers.reg import RegOrVal_ty, Reg32, CompositeReg, Val, Reg64, get_reg_rang
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.TemporaryVariableAllocator import tva
+from typing import Optional
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.vop3.v_mad import VMad
+from src.instructions.sop1.s_mov import SMov
+
+
+class Mad(GenericInstruction):
+    def __init__(self, destination: RegOrVal_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, operand3: RegOrVal_ty, signed=True,  is_scalar=False):
+        self.operand3_val: Optional[Val] = None
+        self.operand3_tmp_reg: Optional[Reg64] = None
+        
+        if isinstance(operand3, Val):
+            tmp_reg_name = tva.generate("mad")
+            self.operand3_tmp_reg = Reg64(tmp_reg_name)
+            self.operand3_val = operand3
+
+        if destination.bit_width == 32:
+            dest_name = tva.generate("mad_dest")
+            dest_hi = Reg32(tva.generate("dest_hi"))
+            destination = CompositeReg(dest_name, [destination, dest_hi])
+
+        name =  "mad_s" if signed else "mad_u"   
+        super().__init__(name, destination, operand1, operand2, operand3, is_scalar=is_scalar)
+
+
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+        self.operand3 = operand3
+        self.signed = signed
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_mad_i64_i32"  if self.signed else "v_mad_u64_u32" 
+    
+    def get_suffix(self) -> str:
+        return "i64_i32"  if self.signed else "u64_u32" 
+    
+    
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        if self.operand3_val is not None:
+            tmp_lo, tmp_hi = get_reg_rang(self.operand3_tmp_reg)
+            ctx.emit_backend(SMov, "s_mov_b32", [tmp_lo, self.operand3_val], "b32")
+            ctx.emit_backend(SMov, "s_mov_b32", [tmp_hi, Val('0')], "b32")
+            return ctx.emit_backend(
+                VMad,
+                self._get_normalize_opcode(),
+                [self.destination, Val('0'), self.operand1, self.operand2, self.operand3_tmp_reg],
+                self.get_suffix(),
+            )
+        return ctx.emit_backend(
+            VMad,
+            self._get_normalize_opcode(),
+            [self.destination, Val('0'), self.operand1, self.operand2, self.operand3],
+            self.get_suffix(),
+        )  

--- a/src/ir/instructions/common/min.py
+++ b/src/ir/instructions/common/min.py
@@ -1,0 +1,19 @@
+from src.ir.instructions.generic import GenericInstruction
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sop2.s_min import SMin
+
+class IRMin(GenericInstruction):
+    def __init__(self, dst, src0, src1,  is_scalar: bool):
+        super().__init__("min", dst, src0, src1, is_scalar=is_scalar)
+   
+    def _get_normalize_opcode(self) -> str:
+        return "s_min_i32"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SMin,
+            self._get_normalize_opcode(),
+            self.operands,
+            "i32",
+        )

--- a/src/ir/instructions/common/mov.py
+++ b/src/ir/instructions/common/mov.py
@@ -1,0 +1,32 @@
+from src.ir.registers.reg import Reg_ty, RegOrVal_ty
+from src.ir.instructions.generic import GenericInstruction
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sop1.s_mov import SMov
+
+
+class Mov(GenericInstruction):
+    def __init__(self, destination: Reg_ty, source: RegOrVal_ty, is_scalar):
+        super().__init__("mov", destination, source, is_scalar=is_scalar)
+        self.destination = destination
+        self.source = source
+
+    def _is_64bit(self) -> bool:
+        return self.destination.bit_width == 64
+
+    def _get_normalize_opcode(self) -> str:
+        return "s_mov_b64" if self._is_64bit() else "s_mov_b32"
+        
+    def get_suffix(self):
+        if self._is_64bit():
+            return "b64"
+        return "b32"
+
+    def to_fill_node(self, state, parents):
+        # NOTE забавный факт, если разбивать mov64 на mov32 x2 то тесты sub показывают более правильный результат(вместо "a + -1" будет "a - 1")
+        return NodeLoweringContext(state, parents).emit_backend(
+            SMov,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )

--- a/src/ir/instructions/common/mul.py
+++ b/src/ir/instructions/common/mul.py
@@ -1,0 +1,165 @@
+from src.ir.registers.reg import Reg_ty, RegOrVal_ty, Reg32, get_reg_rang, Val
+from src.ir.instructions.generic import GenericInstruction
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.vop2.v_mul_f32 import VMulF32
+from src.instructions.vop3.v_mul_lo import VMulLo, VMulHi
+from src.instructions.vop2.v_add import VAdd
+from src.instructions.vop3.v_mad import VMad
+from src.instructions.vop2.v_mac import VMac
+
+class Mul24(GenericInstruction):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, signed=False,  is_scalar=False):
+        name =  "mul_s" if signed else "mul_u"   
+        super().__init__(name, destination, operand1, operand2, is_scalar=is_scalar)
+        self.signed = signed
+
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_mul_i32_i24"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VMulF32,
+            "v_mul_i32_i24",
+            self.operands,
+            "i32_i24",
+        )
+    
+class Mul_f(GenericInstruction):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, signed=False,  is_scalar=False):
+        super().__init__("mul_f", destination, operand1, operand2, is_scalar=is_scalar)
+        self.signed = signed
+
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_mul_f32"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VMulF32,
+            self._get_normalize_opcode(),
+            self.operands,
+            "f32",
+        )
+    
+class Mac_f32(GenericInstruction):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, signed=False,  is_scalar=False):
+        super().__init__("mac_f", destination, operand1, operand2, is_scalar=is_scalar)
+        self.signed = signed
+
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_mac_f32"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VMac,
+            self._get_normalize_opcode(),
+            self.operands,
+            "f32",
+        )
+
+
+class MulLo(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, signed=False,  is_scalar=False):
+        name =  "mul_s" if signed else "mul_u"   
+        super().__init__(name, destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+        self.signed = signed
+
+    def _is_64bit(self) -> bool:
+        return self.destination.bit_width == 64
+    
+    def _get_normalize_opcode(self) -> str:
+        return "v_mul_lo_i32"
+    
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        if not self._is_64bit():
+            return ctx.emit_backend(
+                VMulLo,
+                self._get_normalize_opcode(),
+                self.operands,
+                "u32",
+            )
+        
+        dest_lo, dest_hi = get_reg_rang(self.destination)
+        op1_lo, op1_hi = get_reg_rang(self.operand1)
+        op2_lo, op2_hi = get_reg_rang(self.operand2)
+        ctx.emit_backend(VMulHi, "v_mul_hi_u32", [dest_lo, op1_lo, op2_lo],   "u32")
+        ctx.emit_backend(VMulLo, "v_mul_lo_u32", [dest_hi, op1_lo, op2_hi],   "u32")
+        ctx.emit_backend(VAdd,   "v_add_u32",    [dest_hi, dest_hi, dest_lo], "u32")
+        ctx.emit_backend(VMulLo, "v_mul_lo_u32", [dest_lo, op1_hi, op2_lo],   "u32") 
+        ctx.emit_backend(VAdd,   "v_add_u32",    [dest_hi, dest_hi, dest_lo], "u32")
+        return ctx.emit_backend(VMulLo, "v_mul_lo_u32", [dest_lo, op1_lo, op2_lo], "u32")
+
+
+class MulLo_s(MulLo):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar=False):
+        super().__init__(destination, operand1, operand2, signed=True, is_scalar=is_scalar)
+
+
+
+
+class MulHi(GenericInstruction):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, signed=False,  is_scalar=False):
+        name =  "mul_hi_s" if signed else "mul_hi_u"   
+        super().__init__(name, destination, operand1, operand2, is_scalar=is_scalar)
+        self.signed = signed
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_mul_hi_i32" if self.signed else "s_mul_hi_u32"
+    
+    def get_suffix(self):
+        return "i32" if self.signed else "u32"
+
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(
+            VMulHi,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+
+
+class MulHi_s(MulHi):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar=False):
+        super().__init__(destination, operand1, operand2, signed=True, is_scalar=is_scalar)    
+
+
+class MulWide(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, signed=False,  is_scalar=False):
+        name =  "mul64_s" if signed else "mul64_u"   
+        super().__init__(name, destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+        self.signed = signed
+
+    def _is_64bit(self) -> bool:
+        return True
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_mad_i64_i32"  if self.signed else "v_mad_u64_u32" 
+    
+    def get_suffix(self):
+        return "i64_i32" if self.signed else "u64_u32"
+    
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(
+            VMad,
+            self._get_normalize_opcode(),
+            [self.destination, Val('0'), self.operand1, self.operand2, Val('0')],
+            self.get_suffix(),
+        )    
+    
+class MulWide_s(MulWide):
+    def __init__(self, destination: Reg32, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar=False):
+        super().__init__(destination, operand1, operand2, signed=True, is_scalar=is_scalar)    
+

--- a/src/ir/instructions/common/permute.py
+++ b/src/ir/instructions/common/permute.py
@@ -1,0 +1,23 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import RegOrVal_ty, Reg_ty
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.vop3.v_perm import VPerm
+
+
+class Permute32(GenericInstruction):
+    def __init__(
+        self,
+        destination: Reg_ty,
+        operand1: RegOrVal_ty,
+        operand2: RegOrVal_ty,
+        selector: RegOrVal_ty,
+        is_scalar: bool = False,
+    ):
+        super().__init__("permute32", destination, operand1, operand2, selector, is_scalar=is_scalar)
+
+    def _get_normalize_opcode(self) -> str:
+        return "v_perm_b32"
+    
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        return ctx.emit_backend(VPerm, "v_perm_b32", self.operands, "b32")

--- a/src/ir/instructions/common/store.py
+++ b/src/ir/instructions/common/store.py
@@ -1,0 +1,92 @@
+from src.ir.registers.reg import Reg64, RegOrVal_ty
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.flat.flat_store import FlatStore
+
+class Store(GenericInstruction):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar, size):
+        super().__init__("store", address, value, is_scalar=is_scalar)
+        self.address = address
+        self.value = value
+        self.size = size
+
+    def _get_normalize_opcode(self) -> str:
+        prefix = "flat_store"
+        if self.size == 8:
+            return f"{prefix}_byte"
+        if self.size == 16:
+            return f"{prefix}_short"
+        elif self.size == 32:
+            return f"{prefix}_dword"
+        elif self.size == 64:
+            return f"{prefix}_dwordx2"
+        else:
+            return f"{prefix}_dwordx4"
+        
+    def _get_opcode(self):
+        return FlatStore
+            
+    def writes_first_operand(self) -> bool:
+        return False  
+
+    def get_suffix(self):
+        if self.size == 8:
+            return "byte"
+        if self.size == 16:
+            return "short"
+        elif self.size == 32:
+            return "dword"
+        elif self.size == 64:
+            return "dwordx2"
+        else:
+            return "dwordx4"
+        
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            FlatStore,
+            self._get_normalize_opcode(),
+            self.operands,
+            self.get_suffix(),
+        )
+    
+
+class Store8(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=True, size=8)
+
+class Store16(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=True, size=16)
+
+class Store32(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=True, size=32)
+
+class Store64(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=True, size=64)
+
+class Store128(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=True, size=128)
+
+
+class FStore8(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=False, size=8)
+
+class FStore16(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=False, size=16)
+
+class FStore32(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=False, size=32)
+
+class FStore64(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=False, size=64)
+
+class FStore128(Store):
+    def __init__(self, address: Reg64, value: RegOrVal_ty, is_scalar):
+        super().__init__(address, value, is_scalar=False, size=128)

--- a/src/ir/instructions/common/sub.py
+++ b/src/ir/instructions/common/sub.py
@@ -1,0 +1,65 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import Reg_ty, RegOrVal_ty, get_reg_rang
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.vop2.v_sub import VSub
+
+class Sub(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar: bool = False):
+        super().__init__("sub", destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+        
+    def _is_64bit(self) -> bool:
+        return self.destination.bit_width == 64
+    
+    def _get_normalize_opcode(self) -> str:
+        return "v_sub_u32"
+
+    
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        if not self._is_64bit():
+            return ctx.emit_backend(
+                VSub,
+                self._get_normalize_opcode(),
+                self.operands,
+                "u32",
+            )
+
+        dest_lo, dest_hi = get_reg_rang(self.destination)
+        op1_lo, op1_hi = get_reg_rang(self.operand1)
+        op2_lo, op2_hi = get_reg_rang(self.operand2)
+
+        ctx.emit_backend(
+            VSub,
+            "v_sub_u32",
+            [dest_lo, op1_lo, op2_lo],
+            "u32",
+        )
+        return ctx.emit_backend(
+            VSub,
+            "v_subb_u32",
+            [dest_hi, op1_hi, op2_hi],
+            "u32",
+        )
+
+class Sub_f(GenericInstruction):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar: bool = False):
+        super().__init__("sub", destination, operand1, operand2, is_scalar=is_scalar)
+        self.destination = destination
+        self.operand1 = operand1
+        self.operand2 = operand2
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            VSub,
+            "v_sub_f32",
+            self.operands,
+            "f32",
+        )
+        
+class SubRev(Sub):
+    def __init__(self, destination: Reg_ty, operand1: RegOrVal_ty, operand2: RegOrVal_ty, is_scalar):
+        super().__init__(destination, operand2, operand1, is_scalar=is_scalar)

--- a/src/ir/instructions/common/typed_memory.py
+++ b/src/ir/instructions/common/typed_memory.py
@@ -1,0 +1,231 @@
+from dataclasses import dataclass
+
+from src.ir.TemporaryVariableAllocator import tva
+from src.ir.instructions.common.load import Load
+from src.ir.instructions.common.store import Store
+from src.ir.registers.reg import CompositeReg, Reg32, Reg64, RegOrVal_ty, Reg_ty, Val
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sop2.s_and import SAnd
+from src.instructions.sop2.s_bfe import SBfe
+from src.instructions.sop1.s_mov import SMov
+from src.instructions.vop3.v_perm import VPerm
+
+
+@dataclass(frozen=True)
+class MemoryAccessType:
+    address_space: str
+    base_type: str
+    vector_width: int = 1
+
+    @property
+    def element_bits(self) -> int:
+        return int(self.base_type[1:])
+
+    @property
+    def total_bits(self) -> int:
+        return self.element_bits * self.vector_width
+
+    def to_opencl_type(self) -> str:
+        return f"__{self.address_space} {self.to_value_type()}"
+
+    def to_value_type(self) -> str:
+        base = {
+            "b8": "char",
+            "u8": "char",
+            "s8": "char",
+            "b16": "short",
+            "u16": "short",
+            "s16": "short",
+            "b32": "uint",
+            "u32": "uint",
+            "s32": "int",
+            "b64": "ulong",
+            "u64": "ulong",
+            "s64": "long",
+            "f16": "half",
+            "f32": "float",
+            "f64": "double",
+        }.get(self.base_type, self.base_type)
+
+        if self.vector_width > 1:
+            base = f"{base}{self.vector_width}"
+
+        return base
+
+    def to_element_type(self) -> str:
+        return MemoryAccessType(self.address_space, self.base_type, 1).to_value_type()
+
+
+class TypedMemoryLoad(Load):
+    def __init__(
+        self,
+        destination: Reg_ty,
+        address: Reg64,
+        offset: Val,
+        access_type: MemoryAccessType,
+        is_scalar: bool = False,
+    ):
+        super().__init__(
+            destination,
+            address,
+            offset,
+            is_scalar=is_scalar,
+            size=max(32, access_type.total_bits),
+        )
+        self.access_type = access_type
+        self.packed_value = self._make_internal_reg("typed_ld")
+
+    def to_fill_node(self, state, parents):
+        if self.packed_value is None:              
+            if self._needs_dword_vector_load():
+                return NodeLoweringContext(state, parents).emit_backend(self._get_opcode(), self._get_normalize_opcode(), [self.destination, self.address, self.offset], self.get_suffix())
+            return super().to_fill_node(state, parents)
+        
+        ctx = NodeLoweringContext(state, parents)
+        ctx.emit_backend(self._get_opcode(), self._get_normalize_opcode(), [self.packed_value, self.address, self.offset], self.get_suffix())
+
+
+        assert isinstance(self.destination, CompositeReg)
+        for index, destination in enumerate(self.destination.regs):
+            if index == 0:
+                result = ctx.emit_backend(SAnd, "s_and_b32", [destination, self.packed_value, self._low_mask()], "b32")
+                continue
+
+            selector = self._bfe_selector(index)
+            result = ctx.emit_backend(SBfe, "s_bfe_u32", [destination, self.packed_value, selector], "u32")
+
+        return result
+
+    def _make_internal_reg(self, prefix: str) -> Reg32 | None:
+        if self._needs_small_vector_unpack():
+            return Reg32(tva.generate(prefix))
+        return None
+
+    def _needs_small_vector_unpack(self) -> bool:
+        return (
+            isinstance(self.destination, CompositeReg)
+            and self.access_type.vector_width > 1
+            and self.access_type.element_bits < 32
+            and self.access_type.total_bits <= 32
+        )
+
+    def _low_mask(self) -> Val:
+        return Val(hex((1 << self.access_type.element_bits) - 1))
+
+    def _bfe_selector(self, index: int) -> Val:
+        offset = index * self.access_type.element_bits
+        width = self.access_type.element_bits
+        return Val(hex((width << 16) | offset))
+    
+    def _needs_dword_vector_load(self) -> bool:
+        return (
+            isinstance(self.destination, CompositeReg)
+            and self.access_type.vector_width > 1
+            and self.access_type.element_bits == 32
+            and self.access_type.total_bits in {64, 128}
+        )
+    
+
+
+class TypedMemoryStore(Store):
+    PACK_SELECTOR = Val("0x2010004")
+
+    def __init__(
+        self,
+        address: Reg64,
+        value: RegOrVal_ty,
+        access_type: MemoryAccessType,
+        is_scalar: bool = False,
+    ):
+        super().__init__(
+            address,
+            value,
+            is_scalar=is_scalar,
+            size=max(8, access_type.total_bits),
+        )
+        self.access_type = access_type
+        self.selector = self._make_internal_reg("perm_selector")
+        self.packed_value = self._make_internal_reg("typed_st")
+        self.store_value = self._make_dword_vector_store_value()
+
+
+    def to_fill_node(self, state, parents):
+        if not isinstance(self.value, CompositeReg):
+            return super().to_fill_node(state, parents)
+        
+        if self._needs_small_vector_pack():
+            return self._to_fill_small_vector_store_parts(state, parents)
+        
+        if self.store_value is not None:
+            return self._to_fill_dword_vector_store_parts(state, parents)
+        
+        return super().to_fill_node(state, parents)
+    
+    def _to_fill_small_vector_store_parts(self, state, parents):
+        assert isinstance(self.value, CompositeReg)
+        ctx = NodeLoweringContext(state, parents)
+        opcode = self._get_opcode()
+        first_value = self.value.get_element(0)
+        second_value = self.value.get_element(1)
+        ctx.emit_backend(SMov, "s_mov_b32", [self.selector, self.PACK_SELECTOR], "b32")
+        if self.access_type.vector_width == 2:
+            ctx.emit_backend(VPerm, "v_perm_b32", [self.packed_value, first_value, second_value, self.selector], "b32")
+            return ctx.emit_backend(opcode, self._get_normalize_opcode(), [self.address, self.packed_value], self.get_suffix())
+
+        return super().to_fill_node(ctx.state, ctx.parents)
+    
+
+    def _needs_small_vector_pack(self) -> bool:
+        return (
+            isinstance(self.value, CompositeReg)
+            and self.access_type.vector_width in {2, 4}
+            and self.access_type.element_bits < 32
+            and self.access_type.total_bits <= 32
+        )
+
+    def _make_internal_reg(self, prefix: str) -> Reg32 | None:
+        if self._needs_small_vector_pack():
+            return Reg32(tva.generate(prefix))
+        return None
+    
+    def _needs_dword_vector_store(self) -> bool:
+        return (
+            isinstance(self.value, CompositeReg)
+            and self.access_type.vector_width > 1
+            and self.access_type.element_bits == 32
+            and self.access_type.total_bits in {64, 128}
+        )
+    
+    def _to_fill_dword_vector_store_parts(self, state, parents):
+        assert isinstance(self.value, CompositeReg)
+        assert self.store_value is not None
+
+        ctx = NodeLoweringContext(state, parents)
+        for index, source in enumerate(self.value.regs):
+            ctx.emit_backend(SMov, "s_mov_b32", [self.store_value.get_element(index), source], "b32")
+            
+        return ctx.emit_backend(
+                self._get_opcode(),
+                self._get_normalize_opcode(),
+                [self.address, self.store_value],
+                self.get_suffix()
+        )
+    
+    
+    def _make_dword_vector_store_value(self) -> CompositeReg | None:
+        if not self._needs_dword_vector_store():
+            return None
+
+        assert isinstance(self.value, CompositeReg)
+        if len(self.value) != self.access_type.vector_width:
+            raise ValueError(
+                f"{self.access_type.to_value_type()} store expects "
+                f"{self.access_type.vector_width} source registers"
+            )
+
+        name = tva.generate("typed_st_vec")
+        regs = [
+            Reg32(tva.generate("typed_st_vec_part"))
+            for _ in range(self.access_type.vector_width)
+        ]
+        return CompositeReg(name, regs)

--- a/src/ir/instructions/control_flow.py
+++ b/src/ir/instructions/control_flow.py
@@ -1,0 +1,82 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import PredReg, Val
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sopp.s_cbranch_vccnz import SCbranchVccnz
+from src.instructions.sopp.s_cbranch_vccz import SCbranchVccz
+from src.instructions.sopp.s_branch import SBranch
+from src.instructions.label import Label as backend_Label
+
+class Label(GenericInstruction):
+    def __init__(self, name: Val, is_scalar: bool = True):
+        super().__init__("label", name, is_scalar=is_scalar)
+        self.name = name
+
+    def to_text(self) -> str:
+        return f"label {self.name.to_text()}"
+
+    def writes_first_operand(self) -> bool:
+        return False
+
+    def is_control_flow(self) -> bool:
+        return True
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            backend_Label,
+            self.name,
+            [],
+        )
+
+class Branch(GenericInstruction):
+    def __init__(self, predicate: PredReg, target: Val, is_scalar: bool = True):
+        super().__init__("bra", predicate, target, is_scalar=is_scalar)
+        self.target = target
+
+    def writes_first_operand(self) -> bool:
+        return False
+
+    def is_control_flow(self) -> bool:
+        return True
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SCbranchVccnz,
+            "s_br",
+            self.operands,
+        )
+    
+
+class BranchNot(GenericInstruction):
+    def __init__(self, predicate: PredReg, target: Val, is_scalar: bool = True):
+        super().__init__("bra_n", predicate, target, is_scalar=is_scalar)
+        self.target = target
+
+    def writes_first_operand(self) -> bool:
+        return False
+
+    def is_control_flow(self) -> bool:
+        return True
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SCbranchVccz,
+            "s_nbr",
+            self.operands,
+        )
+class Jump(Branch):
+    def __init__(self, target: Val, is_scalar: bool = True):
+        super().__init__("jump", target, is_scalar=is_scalar)
+        self.target = target
+
+    def writes_first_operand(self) -> bool:
+        return False
+
+    def is_control_flow(self) -> bool:
+        return True
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SBranch,
+            "s_branch",
+            self.operands,
+        )

--- a/src/ir/instructions/generic.py
+++ b/src/ir/instructions/generic.py
@@ -1,0 +1,97 @@
+from src.ir.registers.reg import PredReg, Reg_ty, BaseReg, CompositeReg, expand_register_names, is_range, Reg64
+
+class GenericInstruction:
+    def __init__(
+        self,
+        opcode: str,
+        *operands,
+        is_scalar: bool = False,
+    ):
+        self.opcode = opcode
+        self.operands = tuple(operands)
+        self._is_scalar = is_scalar
+
+    def to_text(self) -> str:
+        if self.operands:
+            operand_strings = [op.to_text() for op in self.operands]
+            return f"{self.opcode} {', '.join(operand_strings)}"
+        return self.opcode
+    
+    
+    def get_operands(self):
+        return self.operands
+    
+    def update_operands(self, *operands):
+        self.operands = tuple(operands)
+    
+    def is_scalar(self):
+        return self._is_scalar
+    
+    def writes_first_operand(self) -> bool:
+        return bool(self.operands)
+
+    def get_predicate(self) -> PredReg | None:
+        return self._predicate
+    
+    def set_predicate(self, predicate: PredReg | None) -> "GenericInstruction":
+        self._predicate = predicate
+        return self
+    
+    def has_predicate(self) -> bool:
+        return self._predicate is not None
+    
+    def is_control_flow(self) -> bool:
+        return False
+    
+    def is_label(self) -> bool:
+        return False
+
+    def get_written_registers(self) -> tuple[Reg_ty, ...]:
+        if not self.writes_first_operand():
+            return ()
+
+        destination = self.operands[0]
+        if isinstance(destination, BaseReg):
+            if is_range(destination) and not isinstance(destination, Reg64):
+                return destination.regs
+            return (destination,)
+        return ()
+    
+    def get_read_registers(self) -> tuple[Reg_ty, ...]:
+        start_idx = 0
+        if self.writes_first_operand():
+            start_idx = 1
+
+        registers: list[Reg_ty] = [
+            operand
+            for operand in self.operands[start_idx:]
+            if isinstance(operand, BaseReg)
+        ]
+        return tuple(registers)
+    
+    def writes_any_predicate(self) -> bool:
+        return any(isinstance(reg, PredReg) for reg in self.get_written_registers())
+    
+    def get_written_register_names(self) -> set[str]:
+        return self._expand_registers(self.get_written_registers())
+
+    def get_read_register_names(self) -> set[str]:
+        return self._expand_registers(self.get_read_registers())
+    
+    def get_written_predicate_names(self) -> set[str]:
+        return {
+            register.name
+            for register in self.get_written_registers()
+            if isinstance(register, PredReg)
+        }
+
+    def to_fill_node(self, state, parents):
+        raise NotImplementedError()
+
+    
+    @staticmethod
+    def _expand_registers(registers: tuple[Reg_ty, ...]) -> set[str]:
+        expanded: set[str] = set()
+        for reg in registers:
+            expanded.update(expand_register_names(reg))
+        return expanded

--- a/src/ir/instructions/ignore.py
+++ b/src/ir/instructions/ignore.py
@@ -1,0 +1,25 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.sopp.s_nop import SNop
+
+class Ignore(GenericInstruction):
+    def __init__(self, *operands, is_scalar):
+        super().__init__("s_nop", is_scalar=is_scalar)
+
+    def to_text(self) -> str:
+        return ""
+    
+    def get_parts(self) -> list[list[str]]:
+        return []
+    
+    def get_operands(self):
+        return []
+    def _get_normalize_opcode(self):
+        return "s_nop"
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            SNop,
+            self._get_normalize_opcode(),
+            self.operands,
+        )
+    

--- a/src/ir/instructions/lowering.py
+++ b/src/ir/instructions/lowering.py
@@ -1,0 +1,39 @@
+import copy
+from collections.abc import Sequence
+from typing import Any
+
+from src.node import Node
+
+
+
+class NodeLoweringContext:
+    def __init__(self, state: Any, parents: list[Node]):
+        self.state = state
+        self.parents = list(parents)
+
+    def emit_backend(
+        self,
+        backend_cls: type,
+        opcode: str,
+        operands: Sequence[Any],
+        suffix: str = ""
+    ) -> Node:
+        node = Node(
+            opcode,
+            list(operands),
+            copy.deepcopy(self.state),
+        )
+        self._attach(node, self.parents)
+        last_node = backend_cls(node, suffix).to_fill_node()
+        return self._advance(last_node)
+
+    @staticmethod
+    def _attach(node: Node, parents: list[Node]) -> None:
+        for parent in parents:
+            node.parent.append(parent)
+            parent.add_child(node)
+
+    def _advance(self, last_node: Node) -> Node:
+        self.state = last_node.state
+        self.parents = [last_node]
+        return last_node

--- a/src/ir/instructions/special/InitReg.py
+++ b/src/ir/instructions/special/InitReg.py
@@ -1,0 +1,21 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import Reg_ty, Val
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.IRspecial.InitReg import InitReg as decInitReg
+
+
+class InitReg(GenericInstruction):
+    def __init__(self, destination: Reg_ty, value: Val, is_scalar: bool):
+        super().__init__("init", destination, value, is_scalar=is_scalar)
+
+    def _get_normalize_opcode(self) -> str:
+        return "s_init"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            decInitReg,
+            self._get_normalize_opcode(),
+            self.operands,
+        )
+    

--- a/src/ir/instructions/special/initPredicate.py
+++ b/src/ir/instructions/special/initPredicate.py
@@ -1,0 +1,29 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import PredReg
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.IRspecial.InitPred import InitPred
+
+
+class InitPredicate(GenericInstruction):
+    def __init__(self, predicate: PredReg, is_scalar: bool = True):
+        super().__init__("init_pred", predicate, is_scalar=is_scalar)
+        self.predicate = predicate
+    
+    def _get_normalize_opcode(self):
+        return "s_ipred"
+
+    def get_written_registers(self) -> tuple[PredReg, ...]:
+        return ()
+
+    def writes_first_operand(self) -> bool:
+        return False
+
+    def has_side_effects(self) -> bool:
+        return True
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            InitPred,
+            self._get_normalize_opcode(),
+            self.operands,
+        )

--- a/src/ir/instructions/special/local_memory.py
+++ b/src/ir/instructions/special/local_memory.py
@@ -1,0 +1,82 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import Reg64, Reg_ty, Val, RegOrVal_ty, Reg32
+from typing import Optional
+from src.ir.TemporaryVariableAllocator import tva
+
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.IRspecial.LocalMem import LocalMemory as DecLocalMemory
+from src.instructions.ds.ds_write import DsWrite
+from src.instructions.ds.ds_read import DsRead
+from src.instructions.ds.ds_add import DsAdd
+from src.instructions.sop1.s_mov import SMov
+
+
+class LocalMemory(GenericInstruction):
+    def __init__(self, destination: Reg64, size, is_scalar: bool = True):
+        super().__init__("local", destination, size, is_scalar=is_scalar)
+    def _get_normalize_opcode(self) -> str:
+        return "s_local"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            DecLocalMemory,
+            self._get_normalize_opcode(),
+            self.operands,
+        )
+    
+
+class LocalStore(GenericInstruction):
+    def __init__(self, destination: Reg_ty, val: Reg_ty, is_scalar: bool = True):
+        super().__init__("local_store", destination, val, is_scalar=is_scalar)
+    def _get_normalize_opcode(self) -> str:
+        return "ds_write_b32"
+    
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            DsWrite,
+            "ds_write_b32",
+            self.operands,
+            "b32"
+        )
+
+
+class LocalLoad(GenericInstruction):
+    def __init__(self, destination: Reg64, from_mem: Reg_ty, is_scalar: bool = True):
+        super().__init__("local_load", destination, from_mem, is_scalar=is_scalar)
+    def _get_normalize_opcode(self) -> str:
+        return "ds_read_b32"
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            DsRead,
+            self._get_normalize_opcode(),
+            self.operands,
+            "b32"
+        )
+
+class LocalAdd(GenericInstruction):
+    def __init__(self, destination: Reg64, val: RegOrVal_ty, is_scalar: bool = True):
+        super().__init__("local_add", destination, val, is_scalar=is_scalar)
+        self.operand1_val: Optional[Val] = None
+        self.operand1_tmp_reg: Optional[Reg32] = None
+        
+        if isinstance(val, Val):
+            tmp_reg_name = tva.generate("ladd")
+            self.operand1_tmp_reg = Reg32(tmp_reg_name)
+            self.operand1_val = val
+
+        self.destination = destination
+        self.operand1 = val
+
+
+    def _get_normalize_opcode(self) -> str:
+        return "ds_add_u32"
+    
+    def to_fill_node(self, state, parents):
+        ctx = NodeLoweringContext(state, parents)
+        if self.operand1_val is not None:
+            ctx.emit_backend(SMov, "s_mov_b32", [self.operand1_tmp_reg, self.operand1_val], "b32")
+            return ctx.emit_backend(DsAdd, "ds_add_u32", [self.destination, self.operand1_tmp_reg], "u32")
+        
+        return ctx.emit_backend(DsAdd, "ds_add_u32", [self.destination, self.operand1], "u32")

--- a/src/ir/instructions/special/mask.py
+++ b/src/ir/instructions/special/mask.py
@@ -1,0 +1,26 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import PredReg
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.IRspecial.ChangeMask import UseMask
+
+
+class ChangeMask(GenericInstruction):
+    def __init__(self, predicate: PredReg, is_scalar: bool = True):
+        super().__init__("change_mask", predicate, is_scalar=is_scalar)
+        self.predicate = predicate
+
+    def _get_normalize_opcode(self):
+        return "change_mask"
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            UseMask,
+            self._get_normalize_opcode(),
+            self.operands,
+        )
+    
+    def writes_first_operand(self) -> bool:
+        return False
+
+    def has_side_effects(self) -> bool:
+        return True

--- a/src/ir/instructions/special/memory.py
+++ b/src/ir/instructions/special/memory.py
@@ -1,0 +1,44 @@
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.registers.reg import Reg64, Reg_ty, Val
+
+
+from src.ir.instructions.lowering import NodeLoweringContext
+from src.instructions.IRspecial.memory import MemoryAllocation as DecMA, StoreInMem
+
+class MemoryAllocation(GenericInstruction):
+    def __init__(self, destination: Reg64, is_scalar: bool = True):
+        super().__init__("alloc", destination, is_scalar=is_scalar)
+        
+    def _get_normalize_opcode(self) -> str:
+        return "s_alloc"
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            DecMA,
+            self._get_normalize_opcode(),
+            self.operands,
+        )
+
+
+class Store(GenericInstruction):
+    def __init__(self, destination: Reg_ty, arg_name: Val, arg_type: Val, offset: Val, is_scalar: bool = True):
+        super().__init__("store", destination, arg_type, arg_name, offset, is_scalar=is_scalar)
+        self.destination = destination
+        self.arg_name = arg_name
+        self.arg_type = arg_type
+        self.offset = offset
+
+    def _get_normalize_opcode(self) -> str:
+        return "s_store"
+    
+    def set_arg_type(self, type_name: str) -> None:
+        self.arg_type = Val(type_name)
+        self.operands = (self.destination, self.arg_type, self.arg_name, self.offset)
+
+
+    def to_fill_node(self, state, parents):
+        return NodeLoweringContext(state, parents).emit_backend(
+            StoreInMem,
+            self._get_normalize_opcode(),
+            self.operands,
+        )

--- a/src/ir/kernel.py
+++ b/src/ir/kernel.py
@@ -1,0 +1,59 @@
+from typing import Any
+from src.ir.registers.reg import PredReg
+from src.ir.kernel_components import (
+    KernelArguments,
+    KernelLocalMemory,
+    KernelPredicates,
+    KernelInstructions,
+)
+
+
+class Kernel:
+    def __init__(self, name: str, work_group_size: list[int]):
+        self.name = name
+        self.work_group_size = work_group_size
+
+        self._instructions = KernelInstructions()
+        self._arguments = KernelArguments()
+        self._local_memory = KernelLocalMemory()
+        self._predicates = KernelPredicates()
+
+
+    @property
+    def instructions(self) -> KernelInstructions:
+        return self._instructions
+
+    @property
+    def arguments(self) -> KernelArguments:
+        return self._arguments
+
+    @property
+    def local_memory(self) -> KernelLocalMemory:
+        return self._local_memory
+    
+    @property
+    def predicates(self) -> KernelPredicates:
+        return self._predicates
+
+    def create_instruction(
+           self,
+           instruction_class: type,
+           *args: Any,
+           is_scalar: bool = False,
+           predicate: str | PredReg | None = None,
+        ) -> "Kernel":
+           instruction = instruction_class(*args, is_scalar=is_scalar)
+           predicate_reg = self._coerce_predicate(predicate)
+           if predicate_reg is not None:
+               instruction.set_predicate(predicate_reg)
+
+           self.instructions.append(instruction)
+           return self
+
+    @staticmethod
+    def _coerce_predicate(predicate: str | PredReg | None) -> PredReg | None:
+        if predicate is None:
+            return None
+        if isinstance(predicate, PredReg):
+            return predicate
+        return PredReg(predicate)

--- a/src/ir/kernel_components.py
+++ b/src/ir/kernel_components.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from src.ir.registers.reg import PredReg, Reg64
+from src.model.config_data import KernelArgument
+from src.opencl_types import evaluate_size, make_asm_type
+from src.ir.instructions.generic import GenericInstruction
+
+
+class KernelArguments:
+    def __init__(self) -> None:
+        self._arg_ptr: Reg64 | None = None
+        self._arguments: list[KernelArgument] = []
+        self._stores_materialized = False
+        self._by_name: dict[str, KernelArgument] = {}
+        self._by_offset: dict[int, KernelArgument] = {}
+
+    def add(
+        self,
+        name: str,
+        type_name: str,
+        const: bool = False,
+        offset: int = 0,
+        hidden: bool = False,
+    ) -> KernelArgument:
+        argument = KernelArgument(
+            type_name=type_name,
+            name=name,
+            offset=offset,
+            size=self._argument_size(name, type_name),
+            hidden=hidden,
+            const=const,
+        )
+        self._arguments.append(argument)
+        self._by_name[name] = argument
+        self._by_offset[offset] = argument
+        return argument
+
+    def get_by_offset(self, offset: int) -> KernelArgument | None:
+        return self._by_offset.get(offset)
+    
+    def get_by_name(self, offset: int) -> KernelArgument | None:
+        return self._by_name.get(offset)
+
+    def all(self) -> list[KernelArgument]:
+        return self._arguments
+
+    def update_type(self, arg_name: str, type_name: str) -> bool:
+        argument = self.get_by_name(arg_name)
+        if argument is None:
+            return False
+
+        argument.type_name = type_name
+        argument.size = self._argument_size(argument.name, type_name)
+        return True
+
+    def update_type_by_offset(self, offset: int, type_name: str) -> bool:
+        argument = self.get_by_offset(offset)
+        if argument is None:
+            return False
+
+        return self.update_type(argument.name, type_name)
+
+    def set_arg_ptr(self, arg_ptr: Reg64) -> None:
+        self._arg_ptr = arg_ptr
+        self._stores_materialized = False
+
+    def arg_ptr(self) -> Reg64 | None:
+        return self._arg_ptr
+
+    def is_materialized(self) -> bool:
+        return self._stores_materialized
+
+    def mark_materialized(self) -> None:
+        self._stores_materialized = True
+
+    @staticmethod
+    def _argument_size(name: str, type_name: str) -> int:
+        if name.startswith("*"):
+            return 8
+
+        size, _ = evaluate_size(make_asm_type(type_name))
+        return size
+
+
+class KernelLocalMemory:
+    def __init__(self) -> None:
+        self._local_memories: dict[str, int] = {}
+        self._materialized = False
+
+    def set(self, name: str, size: int) -> None:
+        self._local_memories[name] = size
+
+    def all(self) -> dict[str, int]:
+        return dict(self._local_memories)
+
+    def is_materialized(self) -> bool:
+        return self._materialized
+
+    def mark_materialized(self) -> None:
+        self._materialized = True
+
+
+class KernelPredicates:
+    def __init__(self) -> None:
+        self._predicates: list[PredReg] = []
+        self._materialized = False
+
+    def add(self, predicate: PredReg) -> None:
+        self._predicates.append(predicate)
+
+    def all(self) -> list[PredReg]:
+        return list(self._predicates)
+
+    def is_materialized(self) -> bool:
+        return self._materialized
+
+    def mark_materialized(self) -> None:
+        self._materialized = True
+
+
+class KernelInstructions:
+    def __init__(self) -> None:
+        self._instructions: list[GenericInstruction] = []
+
+
+    def append(self, instruction: GenericInstruction) -> None:
+        self._instructions.append(instruction)
+        
+    def prepend(self, instruction: GenericInstruction) -> None:
+        self._instructions.append(instruction)
+
+    def append_list(self, instructions: list[GenericInstruction]) -> None:
+        self._instructions = self._instructions + instructions
+
+    def prepend_list(self, instructions: list[GenericInstruction]) -> None:
+        self._instructions = instructions + self._instructions
+
+    def get(self) -> list[GenericInstruction]:
+        return self._instructions

--- a/src/ir/registers/reg.py
+++ b/src/ir/registers/reg.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class BaseReg(ABC):
+    @property
+    @abstractmethod
+    def bit_width(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def type_suffix(self) -> str:
+        pass
+
+    @abstractmethod
+    def to_text(self) -> str:
+        pass
+
+
+class Reg32(BaseReg):
+    def __init__(self, name: str):
+        self._name: str = name
+
+    @property
+    def bit_width(self) -> int:
+        return 32
+
+    @property
+    def type_suffix(self) -> str:
+        return "b32"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def to_text(self) -> str:
+        return self._name
+
+    @classmethod
+    def create_new(cls, name: str) -> Reg32:
+        return cls(name) 
+
+class CompositeReg(BaseReg):
+    def __init__(self, name: str, regs: list[Reg32]):
+        self._regs: tuple[Reg32, ...] = tuple(regs)
+        self._name: str = name
+
+    @property
+    def bit_width(self) -> int:
+        return 32 * len(self._regs)
+
+    @property
+    def type_suffix(self) -> str:
+        return f"b{self.bit_width}"
+
+    @property
+    def regs(self) -> tuple[Reg32, ...]:
+        return self._regs
+
+    @property
+    def name(self) -> str:
+        return self._name
+    
+    def to_text(self) -> str:
+        names = [reg.to_text() for reg in self._regs]
+        return f"{self._name}[{', '.join(names)}]"
+
+    def get_element(self, index: int) -> Reg32:
+        return self._regs[index]
+
+    @classmethod
+    def create_new(cls, name: str, regs: list[Reg32]) -> CompositeReg:
+        return cls(name, regs) 
+    
+    def __len__(self):
+        return len(self._regs)
+    
+
+class Reg64(CompositeReg):
+    def __init__(self, name: str):
+        super().__init__(name, [Reg32(name+"|lo"), Reg32(name+"|hi")])
+
+    @classmethod
+    def create_new(cls, name: str, regs: list[Reg32]) -> CompositeReg:
+        res = cls(name) 
+        res._regs[0]._name = regs[0].name
+        res._regs[1]._name = regs[1].name
+        return res
+    
+class PredReg(Reg64):
+    def __init__(self, name: str):
+        super().__init__(name)
+
+    @property
+    def type_suffix(self) -> str:
+        return "pred"
+
+class Val:
+    def __init__(self, value: str):
+        self._value = value
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    @property
+    def name(self) -> str:
+        return self._value
+    
+    def to_text(self) -> str:
+        return self._value
+    
+    @classmethod
+    def create_new(cls, name: str) -> Reg32:
+        return cls(name) 
+
+
+Reg_ty = Reg32 | Reg64 | PredReg | CompositeReg
+RegOrVal_ty = Reg_ty | Val
+
+def get_reg_rang(reg: Reg_ty) -> tuple[Reg32, ...]:
+    if isinstance(reg, CompositeReg):
+        return tuple(reg.regs)
+    return (reg,)
+
+def expand_register_names(reg: Reg_ty) -> tuple[str, ...]:
+    return tuple(sub_reg.name for sub_reg in get_reg_rang(reg))
+
+def is_reg(reg) -> bool:
+    return isinstance(reg, Reg32)
+
+def is_range(reg) -> bool:
+    return isinstance(reg, CompositeReg)
+
+def is_predicate(reg) -> bool:
+    return isinstance(reg, PredReg)


### PR DESCRIPTION
в этом PR добавляю Kernel который хранит всю нужную информацию о IR, а так же добавляю IR инструкции.

смысл IR инструкций:
1) хранить информацию об инструкции, для удобной обработки 
2) to_fill_node -- нужен для соединения/перевода IR в классы с которыми умеет работать backend(старый декомпилятор) 

особенности инструкций:
1) для удобства перевода IR -> beIR(backend IR) используется класс NodeLoweringContext, с его помощью можно удобно создавать цепочки функций, если одна IR инструкция является комбинацией инструкций beIR(к примеру to_fill_node в MulLo)
2) IR инструкции TypedMemoryLoad и TypedMemoryStore нужны только для работы с PTX  так как у PTX есть проблемы с выводом типов аргументов ядра. а так же данный класс используется для создания операций чтения и записи векторных переменных, это необходимо так как данный инструкции у PTX сильно отличаются от AMD, а следовательно сильно отличаются от того с чем умеет работать дукомпилятор

очевидные и не очень проблемы: 
1) NodeLoweringContext.emit_backend принимает строковое представление опкода и суффикса ```opcode: str, suffix: str = ""```
2) инструкции Load и Store очень плоха принимают флаг is_scalar 