### PR TITLE
Ir pass

### DIFF
--- a/src/ir/passes/base.py
+++ b/src/ir/passes/base.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclass
+class PassContext:
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+class PipelinePass(Protocol):
+    def run(self, ir_unit: object, context: PassContext) -> None: ...
+
+
+class InvalidPipelinePassError(TypeError):
+    def __init__(self, pipeline_name: str, pipeline_pass: object):
+        super().__init__(
+            f"Pipeline '{pipeline_name}' contains invalid pass {pipeline_pass!r}. "
+            f"All passes must implement the 'run' method."
+        )
+
+
+class PassPipeline:
+    def __init__(self, name: str, passes: Iterable[PipelinePass]):
+        self.name = name
+        self._passes = tuple(passes)
+
+    @classmethod
+    def anonymous(cls, passes: Iterable[PipelinePass]) -> PassPipeline:
+        return cls("anonymous-pipeline", passes)
+
+    @classmethod
+    def named(cls, name: str, passes: Iterable[PipelinePass]) -> PassPipeline:
+        return cls(name, passes)
+
+    @property
+    def passes(self) -> tuple[PipelinePass, ...]:
+        return self._passes
+
+    def run(self, ir_unit: object, context: PassContext | None = None) -> PassContext:
+        if context is None:
+            context = PassContext()
+
+        for pipeline_pass in self._passes:
+            run = getattr(pipeline_pass, "run", None)
+            if not callable(run):
+                raise InvalidPipelinePassError(self.name, pipeline_pass)
+            run(ir_unit, context)
+
+        return context

--- a/src/ir/passes/decompilation/__init__.py
+++ b/src/ir/passes/decompilation/__init__.py
@@ -1,0 +1,20 @@
+from src.ir.passes.decompilation.adaptor import KernelToDecompilerPipelineAdaptor
+from src.ir.passes.decompilation.cfg import BuildDecompilerCfgPass
+from src.ir.passes.decompilation.diagnostics import RenderControlFlowGraphPass
+from src.ir.passes.decompilation.emit import EmitOpenCLPass
+from src.ir.passes.decompilation.normalize import NormalizeDecompilerStatePass
+from src.ir.passes.decompilation.postprocess import FinalizeDecompilerValuesPass, ProcessUnrolledLoopsPass
+from src.ir.passes.decompilation.regions import BuildRegionGraphPass
+from src.ir.passes.decompilation.state import DecompilationState
+
+__all__ = [
+    "BuildDecompilerCfgPass",
+    "BuildRegionGraphPass",
+    "DecompilationState",
+    "EmitOpenCLPass",
+    "FinalizeDecompilerValuesPass",
+    "KernelToDecompilerPipelineAdaptor",
+    "NormalizeDecompilerStatePass",
+    "ProcessUnrolledLoopsPass",
+    "RenderControlFlowGraphPass",
+]

--- a/src/ir/passes/decompilation/adaptor.py
+++ b/src/ir/passes/decompilation/adaptor.py
@@ -1,0 +1,15 @@
+from src.ir.kernel import Kernel
+from src.ir.passes.base import PassContext, PassPipeline
+from src.ir.passes.decompilation.state import DecompilationState
+
+
+class KernelToDecompilerPipelineAdaptor:
+    name = "kernel-to-decompiler-pipeline"
+
+    def __init__(self, pipeline: PassPipeline):
+        self.pipeline = pipeline
+
+    def run(self, kernel: Kernel, context: PassContext) -> None:
+        state = DecompilationState.from_kernel(kernel)
+        context.metadata["decompilation_state"] = state
+        self.pipeline.run(state, context)

--- a/src/ir/passes/decompilation/cfg.py
+++ b/src/ir/passes/decompilation/cfg.py
@@ -1,0 +1,132 @@
+from src.ir.instructions.common.endpgm import EndPgm
+from src.ir.instructions.special.mask import ChangeMask, Unmask
+from src.ir.passes.base import PassContext
+from src.ir.passes.decompilation.state import DecompilationState, OpenMask
+from src.logical_variable import ExecCondition
+from src.node import Node
+from src.versions import find_max_and_prev_versions
+
+
+def _get_exec(node: Node) -> ExecCondition:
+    return node.state["$MASK"].exec_condition
+
+
+def _contains_identity(nodes: list[Node], target: Node) -> bool:
+    return any(node is target for node in nodes)
+
+
+def _connect(parent: Node, child: Node) -> None:
+    if parent is child:
+        return
+
+    if not _contains_identity(child.parent, parent):
+        child.add_parent(parent)
+
+    if not _contains_identity(parent.children, child):
+        parent.add_child(child)
+
+
+def _append_unique_node(nodes: list[Node], node: Node) -> None:
+    if not _contains_identity(nodes, node):
+        nodes.append(node)
+
+
+def _find_open_mask_index(
+    open_masks: list[OpenMask],
+    exec_condition: ExecCondition,
+    end: int | None = None,
+) -> int | None:
+    if end is None:
+        end = len(open_masks)
+
+    for index in range(end - 1, -1, -1):
+        if _get_exec(open_masks[index].change_mask) == exec_condition:
+            return index
+    return None
+
+
+def _add_closed_mask_parent(parents: list[Node], open_mask: OpenMask) -> None:
+    if open_mask.previous_branch_end is not None:
+        _append_unique_node(parents, open_mask.previous_branch_end)
+        return
+
+    _append_unique_node(parents, open_mask.change_mask)
+
+
+def _close_open_masks(
+    open_masks: list[OpenMask],
+    exec_condition: ExecCondition,
+    parents: list[Node],
+) -> None:
+    while len(open_masks) > 1 and _get_exec(open_masks[-1].change_mask).is_strict_superset_of(exec_condition):
+        open_mask = open_masks.pop()
+        _add_closed_mask_parent(parents, open_mask)
+
+
+class BuildDecompilerCfgPass:
+    name = "build-decompiler-cfg"
+
+    def run(self, state: DecompilationState, _context: PassContext) -> None:  # noqa: PLR0912
+        decompiler_data = state.decompiler_data
+        masked_blocks = state.masked_blocks
+
+        for instruction in state.kernel.instructions.get():
+            last_node = state.last_node
+            node_state = last_node.state
+            parents = [last_node]
+            change_mask_transition = None
+            else_branch_index = None
+            else_parent_index = None
+            previous_branch_end = None
+
+            if last_node.instruction == "s_branch":
+                parents = []
+
+            if isinstance(instruction, ChangeMask):
+                prev_exec_condition = _get_exec(last_node)
+                next_exec_condition = decompiler_data.exec_registers[instruction.predicate.name]
+                else_parent_condition = prev_exec_condition.negated_sibling_parent(next_exec_condition)
+
+                if next_exec_condition.is_strict_superset_of(prev_exec_condition):
+                    change_mask_transition = "enter"
+                elif next_exec_condition.is_strict_subset_of(prev_exec_condition):
+                    change_mask_transition = "close"
+                    _close_open_masks(masked_blocks, next_exec_condition, parents)
+                elif else_parent_condition is not None:
+                    change_mask_transition = "else"
+                    else_branch_index = _find_open_mask_index(masked_blocks, prev_exec_condition)
+                    if else_branch_index is not None:
+                        previous_branch = masked_blocks[else_branch_index]
+                        else_parent_index = _find_open_mask_index(
+                            masked_blocks,
+                            else_parent_condition,
+                            else_branch_index,
+                        )
+                        if else_parent_index is None:
+                            else_parent_index = max(else_branch_index - 1, 0)
+                        parents = [previous_branch.change_mask]
+                        node_state = previous_branch.change_mask.state
+                        previous_branch_end = last_node
+
+            if isinstance(instruction, EndPgm | Unmask):
+                _close_open_masks(masked_blocks, ExecCondition.default(), parents)
+
+            state.last_node = instruction.to_fill_node(node_state, parents)
+            last_node = state.last_node
+
+            if isinstance(instruction, ChangeMask):
+                if change_mask_transition == "enter":
+                    masked_blocks.append(OpenMask(last_node))
+                elif change_mask_transition == "else" and else_branch_index is not None:
+                    if else_parent_index is None:
+                        else_parent_index = max(else_branch_index - 1, 0)
+                    del masked_blocks[else_parent_index + 1 :]
+                    masked_blocks.append(
+                        OpenMask(
+                            last_node,
+                            previous_branch_end,
+                        )
+                    )
+
+            if len(last_node.parent) > 1:
+                find_max_and_prev_versions(last_node)

--- a/src/ir/passes/decompilation/diagnostics.py
+++ b/src/ir/passes/decompilation/diagnostics.py
@@ -1,0 +1,24 @@
+from src.graph.control_flow_graph import CONTROL_FLOW_GRAPH_ENABLED_CONTEXT_KEY, ControlFlowGraph
+from src.ir.passes.base import PassContext
+from src.ir.passes.decompilation.state import DecompilationState
+from src.utils import get_context
+
+CONTEXT = get_context()
+
+
+class RenderControlFlowGraphPass:
+    name = "render-control-flow-graph"
+
+    def run(self, state: DecompilationState, _context: PassContext) -> None:
+        decompiler_data = state.decompiler_data
+        if not CONTEXT.get(CONTROL_FLOW_GRAPH_ENABLED_CONTEXT_KEY):
+            return
+
+        control_flow_graph = ControlFlowGraph.instance()
+        for node in decompiler_data.starts_regions:
+            control_flow_graph.build_from_node(
+                node=node,
+                program_name=decompiler_data.name_of_program,
+                program_id=decompiler_data.pragram_id,
+            )
+        control_flow_graph.render()

--- a/src/ir/passes/decompilation/emit.py
+++ b/src/ir/passes/decompilation/emit.py
@@ -1,0 +1,10 @@
+from src.code_printer import create_opencl_body
+from src.ir.passes.base import PassContext
+from src.ir.passes.decompilation.state import DecompilationState
+
+
+class EmitOpenCLPass:
+    name = "emit-opencl"
+
+    def run(self, _state: DecompilationState, _context: PassContext) -> None:
+        create_opencl_body()

--- a/src/ir/passes/decompilation/normalize.py
+++ b/src/ir/passes/decompilation/normalize.py
@@ -1,0 +1,18 @@
+from src.decompiler_data import optimize_names_of_vars
+from src.global_data import gdata_type_processing
+from src.ir.passes.base import PassContext
+from src.ir.passes.decompilation.state import DecompilationState
+from src.versions import check_for_use_new_version
+
+
+class NormalizeDecompilerStatePass:
+    name = "normalize-decompiler-state"
+
+    def run(self, state: DecompilationState, _context: PassContext) -> None:
+        decompiler_data = state.decompiler_data
+
+        optimize_names_of_vars()
+        if decompiler_data.global_data:
+            gdata_type_processing()
+        check_for_use_new_version()
+        decompiler_data.remove_unusable_versions()

--- a/src/ir/passes/decompilation/postprocess.py
+++ b/src/ir/passes/decompilation/postprocess.py
@@ -1,0 +1,20 @@
+from src.ir.passes.base import PassContext
+from src.ir.passes.decompilation.state import DecompilationState
+from src.unrolled_loops_processing import process_unrolled_loops
+from src.versions import change_values
+
+
+class FinalizeDecompilerValuesPass:
+    name = "finalize-decompiler-values"
+
+    def run(self, state: DecompilationState, _context: PassContext) -> None:
+        decompiler_data = state.decompiler_data
+        if decompiler_data.checked_variables or decompiler_data.variables:
+            change_values()
+
+
+class ProcessUnrolledLoopsPass:
+    name = "process-unrolled-loops"
+
+    def run(self, _state: DecompilationState, _context: PassContext) -> None:
+        process_unrolled_loops()

--- a/src/ir/passes/decompilation/regions.py
+++ b/src/ir/passes/decompilation/regions.py
@@ -1,0 +1,11 @@
+from src.ir.passes.base import PassContext
+from src.ir.passes.decompilation.state import DecompilationState
+from src.regions.functions_for_regions import make_region_graph_from_cfg, process_region_graph
+
+
+class BuildRegionGraphPass:
+    name = "build-region-graph"
+
+    def run(self, _state: DecompilationState, _context: PassContext) -> None:
+        make_region_graph_from_cfg()
+        process_region_graph()

--- a/src/ir/passes/decompilation/state.py
+++ b/src/ir/passes/decompilation/state.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.decompiler_data import DecompilerData
+from src.expression_manager.expression_manager import ExpressionManager
+from src.ir.kernel import Kernel
+from src.node import Node
+
+
+@dataclass
+class OpenMask:
+    change_mask: Node
+    previous_branch_end: Node | None = None
+
+
+@dataclass
+class DecompilationState:
+    kernel: Kernel
+    decompiler_data: DecompilerData
+    expression_manager: ExpressionManager
+    last_node: Node
+    masked_blocks: list[OpenMask]
+
+    @classmethod
+    def from_kernel(cls, kernel: Kernel) -> DecompilationState:
+        decompiler_data = DecompilerData()
+        expression_manager = ExpressionManager()
+
+        decompiler_data.reset(kernel.name)
+        expression_manager.reset(kernel.name)
+        expression_manager.set_size_of_workgroups(kernel.work_group_size)
+        decompiler_data.set_config_data(kernel)
+
+        last_node = Node([""], [], decompiler_data.initial_state)
+        decompiler_data.set_cfg(last_node)
+
+        return cls(
+            kernel=kernel,
+            decompiler_data=decompiler_data,
+            expression_manager=expression_manager,
+            last_node=last_node,
+            masked_blocks=[OpenMask(last_node)],
+        )

--- a/src/ir/passes/kernel/__init__.py
+++ b/src/ir/passes/kernel/__init__.py
@@ -1,0 +1,11 @@
+from src.ir.passes.kernel.emit_text_ir import EmitTextIRPass
+from src.ir.passes.kernel.init_predicate import MaterializePredicatePass
+from src.ir.passes.kernel.materialize_arguments import MaterializeArgumentStoresPass
+from src.ir.passes.kernel.materialize_memory import MaterializeMemoryPass
+
+__all__ = [
+    "EmitTextIRPass",
+    "MaterializeArgumentStoresPass",
+    "MaterializeMemoryPass",
+    "MaterializePredicatePass",
+]

--- a/src/ir/passes/kernel/emit_text_ir.py
+++ b/src/ir/passes/kernel/emit_text_ir.py
@@ -1,0 +1,26 @@
+from typing import TextIO
+
+from src.ir.kernel import Kernel
+from src.ir.passes.base import PassContext
+
+
+class EmitTextIRPass:
+    name = "emit-text-ir"
+
+    def run(self, kernel: Kernel, context: PassContext) -> None:
+        output_file = self._get_output_file(context)
+        output_file.write(kernel.to_text())
+        output_file.flush()
+
+    @staticmethod
+    def _get_output_file(context: PassContext) -> TextIO:
+        output_file = context.metadata.get("output_file")
+        if output_file is None:
+            raise MissingTextIrOutputError
+
+        return output_file
+
+
+class MissingTextIrOutputError(ValueError):
+    def __init__(self) -> None:
+        super().__init__("Text IR output file is not configured")

--- a/src/ir/passes/kernel/init_predicate.py
+++ b/src/ir/passes/kernel/init_predicate.py
@@ -1,0 +1,15 @@
+from src.ir.instructions.special.init_predicate import InitPredicate
+from src.ir.passes.base import PassContext
+
+
+class MaterializePredicatePass:
+    name = "materialize-predicate"
+
+    def run(self, kernel, _context: PassContext) -> None:
+        if kernel.predicates.is_materialized():
+            return
+
+        init_predicates = [InitPredicate(predicate=reg) for reg in kernel.predicates.all()]
+
+        kernel.instructions.prepend_list(init_predicates)
+        kernel.predicates.mark_materialized()

--- a/src/ir/passes/kernel/materialize_arguments.py
+++ b/src/ir/passes/kernel/materialize_arguments.py
@@ -1,0 +1,29 @@
+from src.ir.instructions.special.memory import MemoryAllocation, Store
+from src.ir.passes.base import PassContext
+from src.ir.registers.reg import Val
+
+
+class MaterializeArgumentStoresPass:
+    name = "materialize-argument-stores"
+
+    def run(self, kernel, _context: PassContext) -> None:
+        if kernel.arguments.is_materialized():
+            return
+
+        arg_ptr = kernel.arguments.arg_ptr()
+        if arg_ptr is None:
+            return
+
+        stores = [
+            Store(
+                arg_ptr,
+                Val(argument.name),
+                Val(argument.type_name),
+                Val(str(argument.offset)),
+            )
+            for argument in kernel.arguments.all()
+        ]
+        instructions = [MemoryAllocation(arg_ptr), *stores]
+
+        kernel.instructions.prepend_list(instructions)
+        kernel.arguments.mark_materialized()

--- a/src/ir/passes/kernel/materialize_memory.py
+++ b/src/ir/passes/kernel/materialize_memory.py
@@ -1,0 +1,27 @@
+from src.ir.instructions.special.init_global import InitGlobalMemory
+from src.ir.instructions.special.local_memory import LocalMemory
+from src.ir.passes.base import PassContext
+from src.ir.registers.reg import Reg64, Val
+
+
+class MaterializeMemoryPass:
+    name = "materialize-memory"
+
+    def run(self, kernel, _context: PassContext) -> None:
+        instructions = []
+
+        if not kernel.global_memory.is_materialized():
+            instructions.extend(
+                InitGlobalMemory(destination=Reg64(name), values=values)
+                for name, values in kernel.global_memory.all().items()
+            )
+            kernel.global_memory.mark_materialized()
+
+        if not kernel.local_memory.is_materialized():
+            instructions.extend(
+                LocalMemory(destination=Reg64(name), size=Val(str(size)))
+                for name, size in kernel.local_memory.all().items()
+            )
+            kernel.local_memory.mark_materialized()
+
+        kernel.instructions.prepend_list(instructions)

--- a/src/ir/passes/pipelines.py
+++ b/src/ir/passes/pipelines.py
@@ -1,0 +1,131 @@
+from src.ir.passes.base import PassPipeline
+from src.ir.passes.decompilation import (
+    BuildDecompilerCfgPass,
+    BuildRegionGraphPass,
+    EmitOpenCLPass,
+    FinalizeDecompilerValuesPass,
+    KernelToDecompilerPipelineAdaptor,
+    NormalizeDecompilerStatePass,
+    ProcessUnrolledLoopsPass,
+    RenderControlFlowGraphPass,
+)
+from src.ir.passes.kernel import (
+    EmitTextIRPass,
+    MaterializeArgumentStoresPass,
+    MaterializeMemoryPass,
+    MaterializePredicatePass,
+)
+from src.ir.passes.ptx import (
+    BuildRegisterFlowPass,
+    InferPTXArgumentTypesPass,
+    InferPTXPointerTypesPass,
+    PTXPredicatesPass,
+)
+
+PTX_PRE_DECOMPILATION_PIPELINE = PassPipeline.named(
+    "ptx-pre-decompilation",
+    [
+        BuildRegisterFlowPass(),
+        InferPTXArgumentTypesPass(),
+        InferPTXPointerTypesPass(),
+        PTXPredicatesPass(),
+    ],
+)
+
+COMMON_KERNEL_LOWERING_PIPELINE = PassPipeline.named(
+    "common-kernel-lowering",
+    [
+        MaterializeArgumentStoresPass(),
+        MaterializeMemoryPass(),
+        MaterializePredicatePass(),
+    ],
+)
+
+CORE_DECOMPILATION_PIPELINE = PassPipeline.named(
+    "core-decompilation",
+    [
+        BuildDecompilerCfgPass(),
+        NormalizeDecompilerStatePass(),
+        BuildRegionGraphPass(),
+    ],
+)
+
+DIAGNOSTIC_OUTPUT_PIPELINE = PassPipeline.named(
+    "diagnostic-output",
+    [
+        RenderControlFlowGraphPass(),
+    ],
+)
+
+POST_DECOMPILATION_PIPELINE = PassPipeline.named(
+    "post-decompilation",
+    [
+        FinalizeDecompilerValuesPass(),
+        ProcessUnrolledLoopsPass(),
+    ],
+)
+
+EMIT_OPENCL_PIPELINE = PassPipeline.named(
+    "emit-opencl",
+    [
+        EmitOpenCLPass(),
+    ],
+)
+
+DECOMPILATION_PIPELINE = PassPipeline.named(
+    "decompilation",
+    [
+        CORE_DECOMPILATION_PIPELINE,
+        DIAGNOSTIC_OUTPUT_PIPELINE,
+        POST_DECOMPILATION_PIPELINE,
+        EMIT_OPENCL_PIPELINE,
+    ],
+)
+
+KERNEL_DECOMPILATION_PIPELINE = PassPipeline.named(
+    "kernel-decompilation",
+    [
+        KernelToDecompilerPipelineAdaptor(DECOMPILATION_PIPELINE),
+    ],
+)
+
+TEXT_IR_PIPELINE = PassPipeline.named(
+    "text-ir",
+    [
+        EmitTextIRPass(),
+    ],
+)
+
+PTX_PIPELINE = PassPipeline.named(
+    "ptx",
+    [
+        PTX_PRE_DECOMPILATION_PIPELINE,
+        COMMON_KERNEL_LOWERING_PIPELINE,
+        KERNEL_DECOMPILATION_PIPELINE,
+    ],
+)
+
+PTX_TEXT_IR_PIPELINE = PassPipeline.named(
+    "ptx-text-ir",
+    [
+        PTX_PRE_DECOMPILATION_PIPELINE,
+        COMMON_KERNEL_LOWERING_PIPELINE,
+        TEXT_IR_PIPELINE,
+    ],
+)
+
+AMD_PIPELINE = PassPipeline.named(
+    "amd",
+    [
+        COMMON_KERNEL_LOWERING_PIPELINE,
+        KERNEL_DECOMPILATION_PIPELINE,
+    ],
+)
+
+AMD_TEXT_IR_PIPELINE = PassPipeline.named(
+    "amd-text-ir",
+    [
+        COMMON_KERNEL_LOWERING_PIPELINE,
+        TEXT_IR_PIPELINE,
+    ],
+)

--- a/src/ir/passes/ptx/__init__.py
+++ b/src/ir/passes/ptx/__init__.py
@@ -1,0 +1,13 @@
+from src.ir.passes.ptx.argument_types import InferPTXArgumentTypesPass
+from src.ir.passes.ptx.pointer_types import InferPTXPointerTypesPass
+from src.ir.passes.ptx.predicates import PTXPredicatesPass
+from src.ir.passes.ptx.register_flow import BuildRegisterFlowPass, RegisterFlowEdge, RegisterFlowGraph
+
+__all__ = [
+    "BuildRegisterFlowPass",
+    "InferPTXArgumentTypesPass",
+    "InferPTXPointerTypesPass",
+    "PTXPredicatesPass",
+    "RegisterFlowEdge",
+    "RegisterFlowGraph",
+]

--- a/src/ir/passes/ptx/argument_types.py
+++ b/src/ir/passes/ptx/argument_types.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from src.ir.instructions.common.typed_memory import MemoryAccessType, TypedMemoryLoad
+from src.ir.passes.base import PassContext
+from src.opencl_types import evaluate_size, make_asm_type
+
+
+class InferPTXArgumentTypesPass:
+    name = "infer-ptx-argument-types"
+
+    def run(self, kernel, context: PassContext) -> None:
+        inferred_types = context.metadata.setdefault("ptx_inferred_argument_types", {})
+        inferred_count = 0
+
+        for instruction in kernel.instructions.get():
+            if not isinstance(instruction, TypedMemoryLoad):
+                continue
+
+            if instruction.address.name != "argptr":
+                continue
+
+            if instruction.access_type.vector_width <= 1:
+                continue
+
+            offset = self._parse_int_value(instruction.offset.value)
+            if offset is None:
+                continue
+
+            argument = kernel.arguments.get_by_offset(offset)
+            if argument is None or argument.name.startswith("*"):
+                continue
+
+            type_name = self._infer_type_name(instruction.access_type, argument)
+            inferred_type = inferred_types.get(offset)
+            if inferred_type is not None:
+                continue
+
+            if not kernel.arguments.update_type_by_offset(offset, type_name):
+                continue
+
+            inferred_types[offset] = type_name
+            inferred_count += 1
+
+        context.metadata["ptx_argument_types_inferred"] = inferred_count
+
+    @staticmethod
+    def _infer_type_name(access_type: MemoryAccessType, argument) -> str:
+        type_name = access_type.to_value_type()
+        declared_size = argument.declared_size if argument.declared_size else argument.size
+        element_size = access_type.element_bits // 8
+
+        if declared_size <= 0 or element_size <= 0:
+            return type_name
+
+        if declared_size % element_size != 0:
+            return type_name
+
+        declared_vector_width = declared_size // element_size
+        if declared_vector_width <= access_type.vector_width:
+            return type_name
+
+        declared_type = MemoryAccessType(
+            access_type.address_space,
+            access_type.base_type,
+            declared_vector_width,
+        ).to_value_type()
+        declared_type_size, _ = evaluate_size(make_asm_type(declared_type))
+        if declared_type_size != declared_size:
+            return type_name
+
+        return declared_type
+
+    @staticmethod
+    def _parse_int_value(value: str) -> int | None:
+        try:
+            return int(value, 0)
+        except ValueError:
+            return None

--- a/src/ir/passes/ptx/pointer_types.py
+++ b/src/ir/passes/ptx/pointer_types.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.ir.instructions.common.load import GenericLoad
+from src.ir.instructions.common.typed_memory import (
+    TypedMemoryFLoad,
+    TypedMemoryFStore,
+    TypedMemoryLoad,
+    TypedMemoryStore,
+)
+from src.ir.passes.base import PassContext
+from src.ir.passes.ptx.register_flow import RegisterFlowGraph
+from src.ir.registers.reg import BaseReg, get_reg_rang
+
+if TYPE_CHECKING:
+    from src.ir.kernel import Kernel
+
+
+PTX_POINTER_SIZE_BITS = 64
+
+
+class InferPTXPointerTypesPass:
+    name = "infer-ptx-pointer-types"
+
+    def run(self, kernel, context: PassContext) -> None:
+        flow = context.metadata.get("register_flow")
+
+        inferred_types = context.metadata.setdefault("ptx_inferred_pointer_arg_types", {})
+        inferred_count = 0
+        for index, instruction in enumerate(kernel.instructions.get()):
+            if isinstance(instruction, TypedMemoryLoad | TypedMemoryFLoad):
+                if self._propagate_pointer_type(
+                    kernel,
+                    flow,
+                    instruction.address.get_element(0),
+                    instruction.access_type.to_opencl_type(),
+                    index,
+                    inferred_types,
+                    set(),
+                ):
+                    inferred_count += 1
+                continue
+
+            if isinstance(instruction, TypedMemoryStore | TypedMemoryFStore):
+                if self._propagate_pointer_type(
+                    kernel,
+                    flow,
+                    instruction.address.get_element(0),
+                    instruction.access_type.to_opencl_type(),
+                    index,
+                    inferred_types,
+                    set(),
+                ):
+                    inferred_count += 1
+                continue
+
+        context.metadata["ptx_pointer_types_inferred"] = inferred_count
+
+    def _propagate_pointer_type(  # noqa: PLR0913
+        self,
+        kernel: Kernel,
+        flow: RegisterFlowGraph,
+        register: BaseReg,
+        type_name: str,
+        use_index: int,
+        inferred_types: dict[int, str],
+        visited: set[tuple[int, str]],
+    ) -> bool:
+        visit_key = (use_index, register.name)
+        if visit_key in visited:
+            return False
+        visited.add(visit_key)
+
+        writer_index = flow.get_writer(use_index, register.name)
+        if writer_index is None:
+            return False
+
+        writer = kernel.instructions.get()[writer_index]
+        if self._try_update_argument_from_load(kernel, writer, type_name, inferred_types):
+            return True
+
+        updated = False
+        for source in writer.get_read_registers():
+            updated = (
+                self._propagate_pointer_type(
+                    kernel,
+                    flow,
+                    get_reg_rang(source)[0],
+                    type_name,
+                    writer_index,
+                    inferred_types,
+                    visited,
+                )
+                or updated
+            )
+
+        return updated
+
+    def _try_update_argument_from_load(  # noqa: PLR0911
+        self,
+        kernel: Kernel,
+        instruction,
+        type_name: str,
+        inferred_types: dict[int, str],
+    ) -> bool:
+        if not isinstance(instruction, GenericLoad):
+            return False
+
+        if instruction.address.name != kernel.arguments.arg_ptr().name:
+            return False
+
+        if instruction.size != PTX_POINTER_SIZE_BITS:
+            return False
+
+        offset = self._parse_int_value(instruction.offset.value)
+        if offset is None:
+            return False
+
+        argument = kernel.arguments.get_by_offset(offset)
+        if argument is None or not argument.name.startswith("*"):
+            return False
+
+        inferred_type = inferred_types.get(offset)
+        if inferred_type is not None:
+            return inferred_type == type_name
+
+        if not kernel.arguments.update_type_by_offset(offset, type_name):
+            return False
+
+        inferred_types[offset] = type_name
+        return True
+
+    @staticmethod
+    def _parse_int_value(value: str) -> int | None:
+        try:
+            return int(value, 0)
+        except ValueError:
+            return None

--- a/src/ir/passes/ptx/predicates.py
+++ b/src/ir/passes/ptx/predicates.py
@@ -1,0 +1,49 @@
+from src.ir.instructions.common.not_instruction import Not
+from src.ir.instructions.generic import GenericInstruction
+from src.ir.instructions.special.mask import ChangeMask, Unmask
+from src.ir.passes.base import PassContext
+from src.ir.registers.reg import PredReg
+
+
+class PTXPredicatesPass:
+    name = "ptx-predicates"
+
+    def run(self, kernel, _context: PassContext) -> None:
+        instructions: list[GenericInstruction] = []
+        open_predicate: PredReg | None = None
+
+        for instruction in kernel.instructions.get():
+            predicate = instruction.get_predicate()
+
+            if predicate is None or instruction.is_control_flow():
+                if open_predicate is not None:
+                    instructions.append(Unmask())
+                    open_predicate = None
+                instructions.append(instruction)
+                continue
+
+            predicate_negated = instruction.is_predicate_negated()
+            mask_predicate = predicate
+            if predicate_negated:
+                mask_predicate = PredReg(f"{predicate.name}Not")
+                kernel.predicates.add(mask_predicate)
+
+            if open_predicate is None:
+                if predicate_negated:
+                    instructions.append(Not(mask_predicate, predicate))
+                instructions.append(ChangeMask(mask_predicate))
+                open_predicate = mask_predicate
+            elif open_predicate.name != mask_predicate.name:
+                instructions.append(Unmask())
+                if predicate_negated:
+                    instructions.append(Not(mask_predicate, predicate))
+                instructions.append(ChangeMask(mask_predicate))
+                open_predicate = mask_predicate
+
+            instruction.set_predicate(None)
+            instructions.append(instruction)
+
+        if open_predicate is not None:
+            instructions.append(Unmask())
+
+        kernel.instructions.replace_all(instructions)

--- a/src/ir/passes/ptx/register_flow.py
+++ b/src/ir/passes/ptx/register_flow.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from src.ir.passes.base import PassContext
+
+if TYPE_CHECKING:
+    from src.ir.kernel import Kernel
+
+
+@dataclass(frozen=True)
+class RegisterFlowEdge:
+    register_name: str
+    writer_index: int
+    reader_index: int
+
+
+@dataclass
+class RegisterFlowGraph:
+    edges: list[RegisterFlowEdge] = field(default_factory=list)
+    writer_by_use: dict[tuple[int, str], int] = field(default_factory=dict)
+    uses_by_writer: dict[int, list[RegisterFlowEdge]] = field(default_factory=dict)
+
+    def get_writer(self, reader_index: int, register_name: str) -> int | None:
+        return self.writer_by_use.get((reader_index, register_name))
+
+
+class BuildRegisterFlowPass:
+    name = "build-register-flow"
+
+    def run(self, kernel, context: PassContext) -> None:
+        graph = self._build(kernel)
+        context.metadata["register_flow"] = graph
+
+    def _build(self, kernel: Kernel) -> RegisterFlowGraph:
+        graph = RegisterFlowGraph()
+        last_writer: dict[str, int] = {}
+
+        for index, instruction in enumerate(kernel.instructions.get()):
+            read_registers = instruction.get_read_register_names()
+            written_registers = instruction.get_written_register_names()
+
+            for register_name in read_registers:
+                writer_index = last_writer.get(register_name)
+                if writer_index is None:
+                    continue
+
+                edge = RegisterFlowEdge(
+                    register_name=register_name,
+                    writer_index=writer_index,
+                    reader_index=index,
+                )
+                graph.edges.append(edge)
+                graph.writer_by_use[(index, register_name)] = writer_index
+                graph.uses_by_writer.setdefault(writer_index, []).append(edge)
+
+            for register_name in written_registers:
+                last_writer[register_name] = index
+        return graph


### PR DESCRIPTION
Добавляю систему пассов.
Пассы поделены на папки и, соответственно, на коммиты.
- Общие пассы.
   Набор пассов с общими преобразованиями: добавление и инициализация локальной/глобальной памяти, предикатные регистры и аргументов.
- Пассы для ptx.
  У ptx есть проблема с выводом типов аргументов, особенно с векторными типами, поэтому нужны дополнительные пассы. Строим граф данных на регистрах -> находим места, где используются аргументы, и выводим тип из инструкции доступа к памяти (формально это пассы, которые пишет пользователь при добавлении нового языка).
- Пассы для декомпилятора.
Просто разбил старый процесс декомпиляции на набор пассов. Нет особых изменений, за исключением алгоритма построения CFG, он находится в cfg.py (это по факту ядро прошлого декомпилятора, центральной темой прошлой системы было распарсить входную строку и выбрать класс, у которого потом вызвать to_fill_node, но теперь мы можем напрямую вызвать функцию to_fill_node).
